### PR TITLE
ci: add Stage 1 no-secrets PR checks

### DIFF
--- a/.github/workflows/stage1-no-secrets-ci.yml
+++ b/.github/workflows/stage1-no-secrets-ci.yml
@@ -9,7 +9,7 @@ permissions:
 jobs:
   python-safe-checks:
     name: Python safe checks
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
 
     steps:

--- a/.github/workflows/stage1-no-secrets-ci.yml
+++ b/.github/workflows/stage1-no-secrets-ci.yml
@@ -1,0 +1,37 @@
+name: Stage 1 No-Secrets CI
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  python-safe-checks:
+    name: Python safe checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: "pip"
+
+      - name: Install CI tools
+        run: |
+          python -m pip install --upgrade pip
+          python -m pip install ruff pytest
+
+      - name: Ruff lint
+        run: python -m ruff check scripts/validate_ospi_manifest.py tests/test_validate_ospi_manifest.py
+
+      - name: Ruff format check
+        run: python -m ruff format --check scripts/validate_ospi_manifest.py tests/test_validate_ospi_manifest.py
+
+      - name: Synthetic unit tests
+        run: python -m pytest tests/test_validate_ospi_manifest.py

--- a/.github/workflows/stage1-no-secrets-ci.yml
+++ b/.github/workflows/stage1-no-secrets-ci.yml
@@ -9,41 +9,58 @@ permissions:
 jobs:
   python-safe-checks:
     name: Python safe checks
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
+    container:
+      image: python:3.11
     timeout-minutes: 10
 
     steps:
       - name: Check out repository
         run: |
-          git init .
-          git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
-          git fetch --no-tags --depth=1 origin "$GITHUB_REF"
-          git checkout --force FETCH_HEAD
+          python - <<'PY'
+          import os
+          import pathlib
+          import shutil
+          import urllib.request
+          import zipfile
 
-      - name: Locate Python 3.11
-        id: python
-        run: |
-          python_bin="$(find /opt/hostedtoolcache/Python -path "*/x64/bin/python" -type f | grep "/3\.11\." | sort -V | tail -n 1)"
-          if [ -z "$python_bin" ]; then
-            echo "Python 3.11 was not found in the hosted tool cache." >&2
-            exit 1
-          fi
-          echo "python_bin=$python_bin" >> "$GITHUB_OUTPUT"
-          "$python_bin" --version
+          archive_url = f"{os.environ['GITHUB_SERVER_URL']}/{os.environ['GITHUB_REPOSITORY']}/archive/{os.environ['GITHUB_REF']}.zip"
+          archive_path = pathlib.Path("/tmp/qorvault-pr.zip")
+          extract_root = pathlib.Path("/tmp/qorvault-pr")
+
+          urllib.request.urlretrieve(archive_url, archive_path)
+          with zipfile.ZipFile(archive_path) as archive:
+              archive.extractall(extract_root)
+
+          checkout_dirs = [path for path in extract_root.iterdir() if path.is_dir()]
+          if len(checkout_dirs) != 1:
+              raise SystemExit(f"Expected one checkout directory, found {len(checkout_dirs)}")
+
+          workspace = pathlib.Path.cwd()
+          for source in checkout_dirs[0].iterdir():
+              target = workspace / source.name
+              if source.is_dir():
+                  shutil.copytree(source, target, dirs_exist_ok=True)
+              else:
+                  shutil.copy2(source, target)
+          PY
+
+      - name: Confirm Python
+        run: python --version
 
       - name: Install CI tools
         run: |
-          "${{ steps.python.outputs.python_bin }}" -m pip install --upgrade pip
-          "${{ steps.python.outputs.python_bin }}" -m pip install ruff pytest
+          python -m pip install --upgrade pip
+          python -m pip install ruff pytest
 
       - name: Ruff lint
         run: |
-          "${{ steps.python.outputs.python_bin }}" -m ruff check scripts/validate_ospi_manifest.py tests/test_validate_ospi_manifest.py
+          python -m ruff check scripts/validate_ospi_manifest.py tests/test_validate_ospi_manifest.py
 
       - name: Ruff format check
         run: |
-          "${{ steps.python.outputs.python_bin }}" -m ruff format --check scripts/validate_ospi_manifest.py tests/test_validate_ospi_manifest.py
+          python -m ruff format --check scripts/validate_ospi_manifest.py tests/test_validate_ospi_manifest.py
 
       - name: Synthetic unit tests
         run: |
-          "${{ steps.python.outputs.python_bin }}" -m pytest tests/test_validate_ospi_manifest.py
+          python -m pytest tests/test_validate_ospi_manifest.py

--- a/.github/workflows/stage1-no-secrets-ci.yml
+++ b/.github/workflows/stage1-no-secrets-ci.yml
@@ -14,24 +14,25 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        run: |
+          git init .
+          git remote add origin "$GITHUB_SERVER_URL/$GITHUB_REPOSITORY.git"
+          git fetch --no-tags --depth=1 origin "$GITHUB_REF"
+          git checkout --force FETCH_HEAD
 
-      - name: Set up Python
-        uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-          cache: "pip"
+      - name: Confirm Python
+        run: python3.11 --version
 
       - name: Install CI tools
         run: |
-          python -m pip install --upgrade pip
-          python -m pip install ruff pytest
+          python3.11 -m pip install --upgrade pip
+          python3.11 -m pip install ruff pytest
 
       - name: Ruff lint
-        run: python -m ruff check scripts/validate_ospi_manifest.py tests/test_validate_ospi_manifest.py
+        run: python3.11 -m ruff check scripts/validate_ospi_manifest.py tests/test_validate_ospi_manifest.py
 
       - name: Ruff format check
-        run: python -m ruff format --check scripts/validate_ospi_manifest.py tests/test_validate_ospi_manifest.py
+        run: python3.11 -m ruff format --check scripts/validate_ospi_manifest.py tests/test_validate_ospi_manifest.py
 
       - name: Synthetic unit tests
-        run: python -m pytest tests/test_validate_ospi_manifest.py
+        run: python3.11 -m pytest tests/test_validate_ospi_manifest.py

--- a/.github/workflows/stage1-no-secrets-ci.yml
+++ b/.github/workflows/stage1-no-secrets-ci.yml
@@ -20,19 +20,30 @@ jobs:
           git fetch --no-tags --depth=1 origin "$GITHUB_REF"
           git checkout --force FETCH_HEAD
 
-      - name: Confirm Python
-        run: python3.11 --version
+      - name: Locate Python 3.11
+        id: python
+        run: |
+          python_bin="$(find /opt/hostedtoolcache/Python -path "*/x64/bin/python" -type f | grep "/3\.11\." | sort -V | tail -n 1)"
+          if [ -z "$python_bin" ]; then
+            echo "Python 3.11 was not found in the hosted tool cache." >&2
+            exit 1
+          fi
+          echo "python_bin=$python_bin" >> "$GITHUB_OUTPUT"
+          "$python_bin" --version
 
       - name: Install CI tools
         run: |
-          python3.11 -m pip install --upgrade pip
-          python3.11 -m pip install ruff pytest
+          "${{ steps.python.outputs.python_bin }}" -m pip install --upgrade pip
+          "${{ steps.python.outputs.python_bin }}" -m pip install ruff pytest
 
       - name: Ruff lint
-        run: python3.11 -m ruff check scripts/validate_ospi_manifest.py tests/test_validate_ospi_manifest.py
+        run: |
+          "${{ steps.python.outputs.python_bin }}" -m ruff check scripts/validate_ospi_manifest.py tests/test_validate_ospi_manifest.py
 
       - name: Ruff format check
-        run: python3.11 -m ruff format --check scripts/validate_ospi_manifest.py tests/test_validate_ospi_manifest.py
+        run: |
+          "${{ steps.python.outputs.python_bin }}" -m ruff format --check scripts/validate_ospi_manifest.py tests/test_validate_ospi_manifest.py
 
       - name: Synthetic unit tests
-        run: python3.11 -m pytest tests/test_validate_ospi_manifest.py
+        run: |
+          "${{ steps.python.outputs.python_bin }}" -m pytest tests/test_validate_ospi_manifest.py


### PR DESCRIPTION
Closes #30

Summary:
- Adds targeted Stage 1 CI for pull request checks.
- This is targeted Stage 1 CI, not full-repo CI.
- It runs on `pull_request` only.
- It uses `permissions: contents: read`.
- It uses Python 3.11.
- It installs only `ruff` and `pytest`.
- It checks only:
  - `scripts/validate_ospi_manifest.py`
  - `tests/test_validate_ospi_manifest.py`

Safety:
- It intentionally avoids production, Framework, database, Qdrant, embeddings, indexing, ingestion, OSPI real-corpus validation, migrations, deployment, and promotion.
- It is visible/non-required at first.

Verification:
- `python -m ruff check scripts/validate_ospi_manifest.py tests/test_validate_ospi_manifest.py`
- `python -m ruff format --check scripts/validate_ospi_manifest.py tests/test_validate_ospi_manifest.py`
- `python -m pytest tests/test_validate_ospi_manifest.py`

Follow-up:
- Stage 1.1 should expand CI scope and consider version pinning after legacy Ruff issues are handled.