### PR TITLE
fix: flag trailing bytes in OSPI manifest validator

### DIFF
--- a/scripts/validate_ospi_manifest.py
+++ b/scripts/validate_ospi_manifest.py
@@ -104,6 +104,16 @@ class JsonStream:
             self._compact()
             return value
 
+    def require_no_trailing_non_whitespace(self) -> None:
+        """Raise if non-whitespace content remains after a top-level value."""
+        self.skip_whitespace()
+        if self._ensure_available():
+            raise json.JSONDecodeError(
+                "Trailing non-whitespace content after top-level JSON value",
+                self.buffer,
+                self.position,
+            )
+
 
 def build_manifest(corpus_path: str | Path, output_path: str | Path) -> dict[str, Any]:
     """Validate an OSPI corpus directory and write a JSON manifest to output_path."""
@@ -216,8 +226,10 @@ def _inspect_json_file(corpus: Path, path: Path) -> tuple[dict[str, Any], list[d
             _mark_empty(entry, warnings, relative_path)
         elif first_char == "[":
             _inspect_top_level_array(reader, entry, file_id)
+            reader.require_no_trailing_non_whitespace()
         elif first_char == "{":
             _inspect_top_level_object(reader, entry, file_id)
+            reader.require_no_trailing_non_whitespace()
         else:
             value = reader.decode_value()
             entry["top_level_shape"] = type(value).__name__

--- a/tests/test_validate_ospi_manifest.py
+++ b/tests/test_validate_ospi_manifest.py
@@ -189,6 +189,28 @@ def test_malformed_and_empty_json_files_warn_without_aborting(tmp_path: Path) ->
     assert {entry["top_level_shape"] for entry in manifest["files"]} == {"malformed", "empty"}
 
 
+def test_trailing_non_whitespace_after_top_level_json_warns_as_malformed(tmp_path: Path) -> None:
+    """Trailing non-whitespace content after complete JSON values should warn."""
+    validator = load_validator()
+    corpus = tmp_path / "corpus"
+    corpus.mkdir()
+    (corpus / "array.json").write_text('[{"a": 1}] trailing-junk', encoding="utf-8")
+    (corpus / "object.json").write_text('{"records": [{"a": 1}]} trailing-junk', encoding="utf-8")
+
+    manifest = validator.build_manifest(corpus, tmp_path / "manifest.json")
+
+    files_by_name = {entry["name"]: entry for entry in manifest["files"]}
+    assert files_by_name["array.json"]["top_level_shape"] == "malformed"
+    assert files_by_name["object.json"]["top_level_shape"] == "malformed"
+    assert files_by_name["array.json"]["record_count"] == 0
+    assert files_by_name["object.json"]["record_count"] == 0
+    assert len(manifest["warnings"]) == 2
+    assert all(
+        "Trailing non-whitespace content after top-level JSON value" in warning["message"]
+        for warning in manifest["warnings"]
+    )
+
+
 def test_checksum_stability_and_no_input_mutation(tmp_path: Path) -> None:
     """Running the validator must not mutate input files or their checksums."""
     validator = load_validator()


### PR DESCRIPTION
Closes #29

## Summary
- RED: added a synthetic validator test for complete top-level array/object JSON values followed by trailing non-whitespace bytes. That case should be reported as malformed instead of silently accepting the parsed leading value.
- GREEN: added a `JsonStream.require_no_trailing_non_whitespace()` check and call it after streamed top-level array/object inspection so trailing junk raises a JSON decode warning path and the file is marked malformed.

## Verification
- `python -m pytest tests/test_validate_ospi_manifest.py` — 11 passed
- `python -m ruff check scripts/validate_ospi_manifest.py tests/test_validate_ospi_manifest.py` — passed
- `python -m ruff format --check scripts/validate_ospi_manifest.py tests/test_validate_ospi_manifest.py` — 2 files already formatted
- Commit hooks — passed: private-key detection, large-file check, branch check, merge-conflict check, debug statement check, EOF/whitespace checks, secrets detection, bandit, ruff, ruff-format, interrogate

## Safety
no real OSPI corpus validation, no OSPI scripts/downloads, no database, no ingestion, no indexing, no embedding, no migration, no deployment, no promotion