### PR TITLE
docs: add OSPI authoritative data-layer roadmap

### DIFF
--- a/docs/ai/architecture/ospi_authoritative_data_layer_roadmap_20260504.md
+++ b/docs/ai/architecture/ospi_authoritative_data_layer_roadmap_20260504.md
@@ -1,0 +1,735 @@
+# OSPI Authoritative Data-Layer Roadmap
+
+**Author:** Claude Code review (Opus 4.7, 1M context)
+**Date:** 2026-05-04
+**Repo HEAD reference:** `8f08baa900732da6cb7e10bc941a5c87c78629cd` (origin/main, post-PR #33)
+**Status:** DRAFT for Donald's review. Prepared for a dedicated docs-only PR.
+No code written.
+
+This memo establishes the architecture for turning the OSPI corpus —
+586,204,574 bytes of state-reported district JSON across 10 datasets and
+698,222 records, as confirmed by the companion STC profile report — into a
+trusted, citeable, queryable fact layer for QorVault.
+
+**Strategic frame:** OSPI is the most authoritative structured dataset
+QorVault has access to. It should be made reliable as a fact layer **before**
+weaker sources (live agenda packets, transcripts, generated summaries) build
+analyses that depend on OSPI numbers. This memo is the planning artifact
+that makes the OSPI work explicit, gated, and dev-only first.
+
+---
+
+## Table of contents
+
+- 1. Existing implementation and current limits
+- 2. Corpus inventory and dataset roles
+- 3. Dataset-by-dataset analytical value
+- 4. Record identity strategy
+- 5. Provenance model
+- 6. Versioning model
+- 7. Manifest dependency
+- 8. Schema / profile strategy
+- 9. SQL vs RAG split
+- 10. Query / citation requirements
+- 11. Dev-only ingestion design
+- 12. Validation gates
+- 13. Test strategy
+- 14. Risks and open decisions
+- 15. Staged issue backlog
+- 16. Relationship to Issue #27
+- 17. Plain-English owner decisions
+
+---
+
+## 1. Existing implementation and current limits
+
+**What exists today:**
+
+- `scripts/validate_ospi_manifest.py` — read-only manifest validator. Produces
+  a deterministic JSON manifest describing every `.json` file under a
+  corpus-root path: SHA-256, top-level shape, record count, schema sample,
+  `record_id_preview`, deterministic `corpus_file_id`, schema_summary.
+  Refuses output paths inside the corpus. Does not mutate inputs.
+- `tests/test_validate_ospi_manifest.py` — 11 synthetic-data tests including
+  the just-merged trailing-bytes guard (PR #33).
+- `.github/workflows/stage1-no-secrets-ci.yml` — Stage 1 CI runs Ruff + the
+  validator's tests on PR. Read-only; no secrets; non-required.
+- The 10 OSPI JSON files live developer-side at
+  `/mnt/qorvault-dev/repo/research/ospi_data/` (gitignored via
+  `research/ospi_data/*.json`) and a parallel copy at
+  `/mnt/qorvault-dev/repo/docs/ospi_data/` (also gitignored as of PR #28).
+- First-pass discovery profile completed by STC on 2026-05-04:
+  `docs/ai/ospi/ospi_corpus_profile_20260504T203334Z.md`. This was read-only,
+  did not ingest data, did not write to a database, and did not modify corpus
+  files.
+
+**What does not exist:**
+
+- No schema-locked, versioned Pydantic per-dataset profile yet. The STC
+  Markdown profile is discovery evidence, not the future executable contract.
+- No schema models, no Pydantic contracts.
+- No record-identity strategy beyond the validator's `corpus_file_id` and
+  preview record fingerprints.
+- No staging tables, no normalized tables, no migrations.
+- No query/citation layer.
+- No SQL facts library.
+- No tests for ingestion or query because the upstream layers don't exist.
+- No mapping from OSPI facts to BoardDocs agenda items.
+
+**Current limits:**
+
+The validator was scoped explicitly as "describe what's in the corpus
+without touching it." It tells us the shape; it does not give us a fact
+layer. Building the fact layer is the work this memo plans.
+
+---
+
+## 2. Corpus inventory and dataset roles
+
+| Dataset | File | Role |
+|---|---|---|
+| Assessment | `assessment.json` | Standardized test results: SBA (ELA, math), WCAS (science). The headline academic-outcome dataset. |
+| Attendance | `attendance.json` | Regular attendance rates. Tracks a federal accountability indicator. |
+| Discipline | `discipline.json` | Disciplinary incident rates, especially exclusionary discipline. Equity-sensitive. |
+| Enrollment | `enrollment.json` | Student head counts by school, grade, and student group. The denominator behind most rate calculations. |
+| Graduation | `graduation.json` | 4-year and (where reported) 5-year graduation rates by student group. |
+| Growth | `growth.json` | Student Growth Percentile (SGP) – measures year-over-year academic growth, separate from absolute achievement. |
+| SQSS | `sqss.json` | School Quality and Student Success indicators – Washington's federal-accountability composite. Identifies schools needing support. |
+| Teacher demographics | `teacher_demographics.json` | Workforce demographic distribution. Useful for representation analysis. |
+| Teacher experience | `teacher_experience.json` | Years-of-experience distribution; novice-teacher rate. Useful for retention analysis. |
+| WaKIDS | `wakids.json` | Kindergarten readiness across six developmental domains. Earliest-grade indicator. |
+
+**Confirmed STC profile totals**
+(`docs/ai/ospi/ospi_corpus_profile_20260504T203334Z.md`):
+586,204,574 bytes across 10/10 expected files; 698,222 records; 0 byte
+delta; 0 record delta; no missing expected files; no unexpected JSON files;
+all 10 top-level shapes are arrays, and all dataset schema summaries report
+0 nested paths.
+
+**Roles in QorVault analyses:**
+
+- **Outcome metrics:** assessment, growth, graduation, WaKIDS.
+- **Behavior metrics:** attendance, discipline.
+- **Structural metrics:** enrollment, SQSS.
+- **Workforce metrics:** teacher demographics, teacher experience.
+
+---
+
+## 3. Dataset-by-dataset analytical value
+
+For each dataset, the *kind* of question it can answer and the *quality* of
+that answer when grounded in OSPI data rather than scraped agenda summaries.
+
+- **assessment** — "What share of KSD students met standard in math at the
+  elementary level in 2024-25?" Authoritative for cohort/year/subject. Watch
+  for suppressed cells in small subgroups.
+- **attendance** — "Has regular attendance recovered since 2021-22?" Strong
+  for trend analysis at school and district level. Definition changes over
+  time; year-on-year comparisons need definitional check.
+- **discipline** — "Are exclusionary discipline events declining and is the
+  decline equitable across student groups?" Equity questions often hinge on
+  small-cell suppression; some answers will be "OSPI suppressed."
+- **enrollment** — "How has KSD's overall enrollment changed over five
+  years, and how does that vary by grade?" Cleanest dataset; few suppression
+  issues at school level.
+- **graduation** — "Is graduation rate improving for student groups?"
+  Subject to small-cohort suppression; needs careful group selection.
+- **growth** — "Is academic growth keeping pace with achievement levels?"
+  SGP is a percentile rank; values do not aggregate the way percentages do.
+  Need careful interpretation in any answer.
+- **sqss** — "Which KSD schools are flagged for support and what tier?"
+  Tier labels change format across years; year-aware decoding is required.
+- **teacher_demographics** — "Does the workforce reflect the student body's
+  demographics?" Side-by-side comparison with enrollment is the natural
+  question.
+- **teacher_experience** — "Has the share of novice teachers increased?"
+  Useful for retention storylines.
+- **wakids** — "Are entering kindergartners meeting the readiness benchmark
+  across six domains?" Six-domain structure means a single dataset can
+  produce six near-independent answers per cohort/year/group.
+
+These analytical roles inform Section 9 (what belongs in SQL vs. RAG).
+
+---
+
+## 4. Record identity strategy
+
+Every OSPI fact must be reachable by a stable, deterministic identity that
+survives corpus snapshots and schema evolution.
+
+**Composite identity:**
+
+```
+ospi_record_id = stable_hash(
+    dataset,                  # e.g. "assessment"
+    reporting_year,           # canonicalized e.g. "2024-2025"
+    district_code,            # OSPI district code, zero-padded
+    school_code | NULL,       # OSPI school code, zero-padded; NULL for district-level rows
+    student_group | NULL,     # canonicalized student-group code; NULL for "All Students"
+    measure_dims,             # dataset-specific dims (subject, grade band, indicator type)
+    record_payload_hash       # SHA-256 of the canonicalized record JSON
+)
+```
+
+**Why each component:**
+
+- `dataset` keeps records from the same dimensions but different files
+  distinguishable.
+- `reporting_year` is canonicalized to a single format (`YYYY-YYYY`) with
+  validation against acceptable historical formats (decision O3).
+- `district_code` and `school_code` use OSPI's stable codes, zero-padded
+  for sort-friendly storage.
+- `student_group` is canonicalized to a controlled vocabulary (decision O4).
+- `measure_dims` is a dataset-specific tuple recording the secondary
+  dimensions that distinguish two records of the same year/school/group
+  (e.g., subject + grade-band for assessment).
+- `record_payload_hash` detects changes to a record's contents under the
+  same identity (revision detection).
+
+**Stable across reruns:** the identity is a deterministic function of
+inputs. Rerunning the profile or ingestion produces the same `ospi_record_id`
+for the same source row.
+
+**Linkage to validator output:** the manifest's `record_id_preview` and
+`corpus_file_id` are content-addressed by file and record-index plus
+canonicalized JSON. Profile and ingestion layers consume those as inputs
+to the composite identity above.
+
+---
+
+## 5. Provenance model
+
+Every fact carries the full provenance chain. Anything missing a chain
+element is treated as untrusted and cannot ship in a citation.
+
+| Field | Where it comes from | Why it matters |
+|---|---|---|
+| `source_file_path` | manifest `relative_path` | Reproducibility — "where on disk." |
+| `source_file_sha256` | manifest `sha256` | Bit-exact integrity check. |
+| `manifest_id` | manifest `corpus_file_id` (or new manifest-level ID) | Ties fact to a frozen manifest snapshot. |
+| `manifest_sha256` | hash of the manifest itself | Detects manifest drift. |
+| `profile_run_id` | profile job UUID | Which profile run produced the schema/typing. |
+| `ingestion_run_id` | ingestion job UUID | Which run wrote the fact to dev DB. |
+| `schema_version` | Pydantic model version (e.g. `ospi.assessment/v1`) | Enables schema migration safely. |
+| `record_payload_hash` | SHA-256 of canonical record JSON | Revision detection. |
+| `extraction_timestamp` | UTC instant the fact was derived | Audit log. |
+| `corpus_snapshot_version` | versioned snapshot of the dataset (Section 6) | Year/release awareness. |
+
+**Citation surface:** when an answer cites an OSPI fact, the JSON returned
+to a caller must include a minimum subset of these fields — see Section 10.
+
+---
+
+## 6. Versioning model
+
+Five versioned things, each independent:
+
+| What | Why versioned | Lifecycle |
+|---|---|---|
+| **Corpus snapshot** | OSPI publishes new annual data; old data may be revised. | Each download produces a snapshot id (date + manifest hash). Old snapshots remain queryable. |
+| **Manifest** | The validator output is the gate to profiling and ingestion. | One per snapshot. Pinned by hash. |
+| **Schema version** | Field sets evolve; codes get retired. | Per dataset (`ospi.assessment/v1` etc.). Bump when meaning changes. |
+| **Ingestion run version** | Each run stamps a version on the rows it writes. | New version per run; old rows preserved. |
+| **Query/citation contract version** | Public surface of the citation API. | Bump when fields change shape. Old contract supported until callers migrate. |
+
+**Snapshot lifecycle policy** (decision O5): keep all historical snapshots
+in dev DB unless storage forces eviction. A historical answer cited
+against snapshot `2026-04-30T00:00Z` should remain re-derivable indefinitely.
+
+---
+
+## 7. Manifest dependency
+
+The validator's manifest is the **gate** to everything downstream.
+
+**Future schema-locked profiling will refuse to run without a manifest.** The
+profile job reads the manifest hash from a config or argument; if the on-disk
+corpus's manifest-of-record disagrees, the profile aborts. The completed STC
+discovery profile is a read-only companion artifact; it does not yet create
+this enforcement contract.
+
+**Ingestion refuses to run without a manifest reconciliation.** Before
+writing a single row to dev DB, ingestion verifies:
+
+1. The manifest file exists at the expected path.
+2. The manifest's `corpus_path` matches the configured corpus path.
+3. Re-deriving the manifest's SHA-256 over each file matches the manifest's
+   stored hash. (Spot-check vs full re-derive is decision O6.)
+4. No file in the manifest is missing on disk; no file on disk is missing
+   from the manifest.
+
+**Query layer refuses unrecognized snapshots.** When a caller asks for
+"2024-25 KSD assessment in math," the query layer maps that to a specific
+snapshot id and refuses if no ingestion run has loaded that snapshot.
+
+This makes the manifest the contract between layers: profiling, ingestion,
+and querying all bind to the same frozen description of what the corpus is.
+
+---
+
+## 8. Schema / profile strategy
+
+Per dataset, the completed STC profile is the first-pass evidence artifact:
+counts, field coverage, suppression patterns, year ranges, Kent School
+District signal checks, and numeric-string patterns. The future
+schema-locked **profile** is a deterministic, versioned JSON document
+containing:
+
+- **Top-level shape** — verified to be array (the manifest already confirms
+  this for current corpus).
+- **Record count** — exact match against manifest.
+- **Field set** — the union of keys observed across all records, with
+  per-key occurrence count.
+- **Type inference per field** — string vs numeric vs boolean, with a
+  histogram of representations (e.g., `"82.4"` vs `82.4` vs `null` vs `"*"`).
+- **Null / suppression patterns** — the set of values OSPI uses to indicate
+  suppressed or missing data: `null`, `""`, `"*"`, `"<10"`, `"Suppressed"`,
+  `"N<10"`, etc. Each gets a normalized canonical form.
+- **Year ranges** — distinct values of `schoolyear` (or its dataset-specific
+  equivalent), validated against an allow-list of formats.
+- **District / school identifiers** — distinct codes; cross-referenced
+  against a canonical district/school registry (decision O7).
+- **Candidate primary keys** — minimum-cardinality field combinations that
+  uniquely identify a row. Used to validate the record-identity strategy
+  in Section 4.
+- **Schema version stamp** — the profile is a versioned artifact; rerunning
+  with new code produces a new version.
+
+**Tooling:** the profile job is Python stdlib + Pydantic v2. It reads only
+the manifest plus the JSON files in the corpus path. It writes a single
+profile JSON per dataset to a directory **outside** the corpus (refused if
+inside, same rule as the validator).
+
+**Profiles are committed to git** (per dataset, under
+`docs/ai/ospi/profiles/`) once they are produced. They are small and
+human-reviewable; the underlying data is not.
+
+---
+
+## 9. SQL vs RAG split
+
+**Hard rule: numeric facts never depend on embeddings.** A claim like "KSD
+4-year graduation rate was 91.0% in 2023-24" must come from a deterministic
+SQL query against typed columns, never from an LLM summarizing retrieved
+chunks of a JSON record.
+
+**Belongs in SQL:**
+
+- Every numeric, categorical, and identifier field from every OSPI dataset.
+- Suppression flags as enum columns.
+- Year ranges, codes, controlled-vocabulary values.
+- Aggregation views (district totals, group breakdowns, year-over-year
+  deltas).
+
+**Optionally RAG-able later (not V1):**
+
+- Per-dataset documentation (what each field means, suppression conventions,
+  definitional changes across years). Embedding this is potentially useful
+  for "what does WaKIDS measure?" questions but is not required to answer
+  data questions.
+- Cross-dataset disambiguation notes (e.g., "growth percentile is not the
+  same as percent meeting standard").
+- Mapping notes for agenda-to-OSPI evidence retrieval (later).
+
+**Never RAG-able:**
+
+- Numeric values.
+- Suppression decisions.
+- Identifier resolution.
+- Aggregations.
+- Anything that requires arithmetic or set logic.
+
+**Operational rule:** the agenda-analysis worker, when it needs an OSPI
+fact, calls the OSPI query/citation layer (deterministic SQL → JSON facts)
+and treats the response as a tool result. The LLM may generate prose around
+the fact but cannot generate the fact.
+
+---
+
+## 10. Query / citation requirements
+
+An answer that cites an OSPI fact must carry **all** of the following or
+it is not trustworthy:
+
+```json
+{
+  "fact_id": "ospi:assessment:2024-2025:17415:0123:5_meeting_standard_math:5",
+  "value": "62.4",
+  "value_kind": "percent",
+  "value_unit": "percent_students_meeting_standard",
+  "suppression_status": "reported",
+  "suppression_code": null,
+  "dimensions": {
+    "dataset": "assessment",
+    "reporting_year": "2024-2025",
+    "district_code": "17415",
+    "district_name": "Kent School District",
+    "school_code": "0123",
+    "school_name": "Example Elementary",
+    "student_group": "All Students",
+    "subject": "math",
+    "grade_band": "5"
+  },
+  "provenance": {
+    "source_file_path": "research/ospi_data/assessment.json",
+    "source_file_sha256": "...",
+    "manifest_id": "ospi-manifest-validator/v1:...",
+    "manifest_sha256": "...",
+    "corpus_snapshot_version": "2026-04-30T00:00Z",
+    "schema_version": "ospi.assessment/v1",
+    "ingestion_run_id": "uuid",
+    "extraction_timestamp": "2026-05-04T12:00:00Z"
+  },
+  "record_payload_hash": "..."
+}
+```
+
+**Suppressed cells must surface as suppression, not as missing.** A
+suppressed value carries `value: null`, `suppression_status: "suppressed"`,
+and the suppression code. The renderer presents "OSPI suppressed
+(small group)" rather than silently dropping the row.
+
+**Citations must round-trip.** Given a fact_id, the query layer must be
+able to re-derive the exact citation. This forces deterministic IDs.
+
+**Citation contract is versioned.** Bumps go through a PR with a migration
+window for callers (the agenda-analysis renderer will be the first caller).
+
+---
+
+## 11. Dev-only ingestion design
+
+**Three-tier storage** in dev Postgres (same `qorvault` database, new
+`ospi_facts` schema for namespace isolation):
+
+| Tier | Table family | Purpose |
+|---|---|---|
+| Raw | `ospi_facts.raw_<dataset>` | One row per input JSON record, with full original JSON in `payload_jsonb`, plus identity columns and provenance. Source of truth for everything below. |
+| Normalized | `ospi_facts.<dataset>` | Typed columns per dataset's schema model; one row per record; FK to raw. The query layer hits these. |
+| Aggregated | `ospi_facts.v_<dataset>_<measure>` views | Pre-computed aggregations (district totals, year deltas). All views derive from normalized; no parallel ETL. |
+
+**Ingestion flow** (per dataset, per snapshot):
+
+1. Manifest reconciliation gate (Section 7).
+2. Stream JSON file with the validator's `JsonStream` (already proven; no
+   new parser).
+3. For each record: compute `record_payload_hash`, stamp provenance,
+   `INSERT … ON CONFLICT DO NOTHING` into raw table keyed by
+   `(snapshot_version, dataset, record_index_in_file)`.
+4. From raw, project into normalized table via a deterministic transform
+   defined by the dataset's Pydantic model. Failures emit a warning row
+   into `ospi_facts.ingestion_warnings` and skip; they do not abort the run.
+5. After full ingest, run reconciliation queries: row counts per
+   normalized table must match manifest record counts (minus skipped/warned
+   rows).
+
+**No production writes ever.** The dev DB is separate. Production schema
+changes require their own migration design and approval.
+
+**No migrations applied until separately approved.** This memo specifies
+the schema design; the actual `CREATE TABLE` DDL ships as a follow-up
+issue with its own review.
+
+**Idempotency:** rerunning the same snapshot's ingestion is a no-op for
+unchanged rows (`ON CONFLICT DO NOTHING`) and adds new rows for any new
+records the manifest covers. Snapshots are immutable post-ingest.
+
+**Resumability:** ingestion checkpoints by `(dataset, file_offset)` in
+`ospi_facts.ingestion_checkpoints`; a crash mid-run resumes from the last
+flushed offset on restart.
+
+---
+
+## 12. Validation gates
+
+Four gates, each blocking the next layer until passed.
+
+1. **Before profiling** — manifest exists, manifest passes
+   `validate_ospi_manifest.py` against the on-disk corpus, and Donald has
+   approved a corpus snapshot version.
+2. **Before dev ingestion** — every dataset has a committed profile
+   (Section 8) reviewed and approved; every dataset has a committed Pydantic
+   schema (Section 8); manifest reconciles bit-for-bit.
+3. **Before query layer goes live (in dev)** — ingestion completed for at
+   least one full snapshot; reconciliation queries pass; citation
+   round-trips for a sampled set of records.
+4. **Before agenda automation can consume OSPI facts** — query/citation
+   contract version is locked; failure modes (suppressed, missing, schema
+   mismatch) are documented; the agenda renderer's "OSPI fact" tool has its
+   own contract test.
+
+Each gate is a checklist item in the corresponding issue. None is
+"automatic" — each is owner-approved.
+
+---
+
+## 13. Test strategy
+
+**In CI (Stage 1.x as it expands):**
+
+- **Synthetic unit tests** — parser tests for type coercion, suppression
+  handling, year-format canonicalization, record identity.
+- **Fixture-based profile tests** — small JSON fixtures for each dataset
+  shape (a few records each); profile job runs against fixtures and
+  asserts the produced profile JSON.
+- **Schema contract tests** — Pydantic models validate against fixtures;
+  invalid records fail closed.
+- **Citation formatting tests** — given a synthetic ingestion result, the
+  citation builder produces a JSON conforming to the contract; required
+  fields present; missing-provenance cases fail closed.
+- **Ingestion against test DB** — pytest with a disposable Postgres test
+  schema (created per session, dropped after), fixture data only.
+
+**Not in CI by default:**
+
+- Real-corpus profile runs (large, slow, and the corpus isn't in git).
+- Real-corpus ingestion runs.
+- Performance/scaling tests.
+
+**Optional integration tests** runnable locally with explicit
+`OSPI_RUN_REAL_CORPUS=1` env gate. Not required for merge. Tracks corpus
+freshness when Donald wants to validate against the real files.
+
+---
+
+## 14. Risks and open decisions
+
+| # | Risk / open question |
+|---|---|
+| R1 | **Suppression conventions vary across files.** assessment uses one set of codes; SQSS may use another. A naïve normalizer could conflate "suppressed for privacy" with "suppressed because not yet reported." Mitigation: use the completed STC profile's Null, Missing, And Suppression Patterns table, which confirms material variance across assessment, attendance, graduation, growth, SQSS, and WaKIDS; then build a canonical taxonomy with provenance before normalization. |
+| R2 | **Year format is inconsistent.** Some datasets store `"2024-25"`, others `"2024-2025"`, others a numeric end-year. Mitigation: canonicalize on ingest and validate during profile; refuse unknown formats. |
+| R3 | **District/school code stability across years.** Codes can be retired, merged, renamed (e.g., school closures). A code valid in 2018-19 may not exist in 2024-25. Mitigation: build a registry table that captures code-lifetime windows; reject ingestion of facts whose codes don't validate against the registry for the reporting year. |
+| R4 | **Numeric values stored as strings.** The STC profile confirms numeric-like values are string-encoded across the current 10 datasets, with percentages and placeholders mixed in. Coercion errors silently corrupt data. Mitigation: strict Pydantic models with explicit string→number coercion + suppression-code allowlist. Anything else fails ingestion. |
+| R5 | **Multi-grain rows.** Some datasets emit district-level, school-level, and grade-level rows in the same file. A naïve aggregate sum would double-count. Mitigation: profile detects grain via key cardinality; normalized table includes a `grain` enum column; aggregation views explicitly filter by grain. |
+| R6 | **Volume in dev DB.** ~700k rows × 10 datasets, normalized + raw + warnings ≈ 5-10 million rows + raw JSONB blobs. Manageable on Smeltor but warrants disk planning. Mitigation: estimate disk per dataset during profiling; storage check is a gate before first ingestion. |
+| R7 | **Cross-dataset analyses require reconciled keys.** "Compare attendance and discipline at the same school" depends on consistent school-code semantics. Mitigation: registry-based canonical IDs, plus a `dataset_join_compatibility` matrix in docs. |
+| R8 | **Corpus comes from `download_ospi.py`, which we have not audited.** The corpus on disk is presumed to match what OSPI publishes, but we haven't verified the download script doesn't transform values en route. Mitigation: audit `download_ospi.py` as a Stage-0 task before any ingestion. |
+| R9 | **OSPI may publish corrections.** A "corrected" file with the same name and different bytes is detected by manifest hash drift. Mitigation: `corpus_snapshot_version` carries the manifest hash; downstream ingestion treats new manifest as a new snapshot. |
+| R10 | **Trust boundary.** Downstream callers (agenda renderer) might over-claim by treating OSPI facts as ground truth. Mitigation: every citation includes "Source: OSPI Report Card, [year]" framing; the renderer must surface OSPI as a source, not as omniscient truth. |
+
+---
+
+## 15. Staged issue backlog
+
+Sequencing maximizes safe verifiability and aligns with the gates in
+Section 12.
+
+| Backlog item | Description | Gate it serves |
+|---|---|---|
+| **OSPI corpus profile — schema-lock (Stage 0 design)** | Convert STC's discovery profile into a Pydantic-versioned, committed per-dataset profile artifact with inputs, outputs, fixtures, tests, and gate criteria. | Gate 1 (before schema-lock) |
+| **OSPI authority and provenance model — OspiCitation contract** | Lock the citation field schema (Section 5 + Section 10). Pydantic model for `OspiCitation`. Tests for required-fields-present. | Gate 3 (before query layer) |
+| **OSPI per-dataset schema and record-identity design** | Per-dataset Pydantic schemas + record-identity composite. The schema-locked profile feeds this. Tests against fixtures. | Gate 2 (before dev ingestion) |
+| **OSPI dev-only ingestion — table design and migration plan (docs only)** | Schema for `ospi_facts.raw_*` and `ospi_facts.<dataset>` tables, plus migration plan, plus checkpoint design. Docs only. | Gate 2 (before dev ingestion) |
+| **OSPI dev-only ingestion DDL + ingest job — first dataset (enrollment)** | The actual `CREATE TABLE` migration applied to dev DB only, plus the streaming ingest job for one dataset. | Gate 2 (before dev ingestion) |
+| **OSPI query / citation layer — deterministic SQL → JSON facts** | Deterministic SQL → JSON facts API. Versioned contract. Tests for citation round-trip. | Gate 3 (before query layer) |
+| **OSPI SQL facts library — parameterized common analyses** | Parameterized queries for the most common analyses (district totals, year deltas, group breakdowns). Lives as views or as Python helpers; same contract. | Gate 3 (before query layer) |
+| **OSPI-to-agenda evidence mapping** | Spec for how the agenda-analysis worker fetches OSPI facts as evidence for an item. Depends on the agenda-analysis worker shipping first. | Gate 4 (before agenda automation consumes OSPI) |
+| **Stage 1.1 CI hardening for OSPI-related code** | Expand Ruff scope to OSPI ingestion code; add the OSPI-specific synthetic test scopes to the CI workflow. Pin Ruff/pytest versions. | Cross-cutting |
+
+**Per-dataset rollout for the first ingestion job:** the first ingestion
+target is the cleanest dataset (enrollment in my preliminary view) so we
+exercise the full path without fighting suppression complexity. After that
+lands and reconciles, add datasets in increasing complexity.
+
+---
+
+## 16. Relationship to Issue #27
+
+Issue #27 ("Clarify route semantics: hybrid is retrieval-only after PR
+#26") is small and **unrelated** to the OSPI workstream's data path.
+
+- #27 affects how the `rag_api` answers ad-hoc queries about agenda
+  documents from Qdrant.
+- The OSPI work doesn't go through `rag_api`'s hybrid route at all — it
+  hits dedicated SQL queries against `ospi_facts.*` tables that don't yet
+  exist.
+- The agenda-analysis worker (a future consumer of both layers) will use
+  the **retrieval-only** path for evidence retrieval in its analysis loop.
+  That's exactly what #27 codifies.
+
+**Recommendation: run #27 in parallel.** It's a small clarification fix
+that helps documentation, helps the agenda-analysis design, and helps any
+caller building on the retrieval layer. The OSPI workstream is much
+larger; #27 should not be allowed to block it, and OSPI should not block
+#27. Do them concurrently.
+
+---
+
+## 17. Plain-English owner decisions
+
+These are the explicit choices that need Donald's input. None block this
+memo. They block the issues they correspond to.
+
+### O1 — Memo location
+
+This memo is at `docs/ai/architecture/`. Should I move it to
+`docs/ai/ospi/` to group all OSPI material together?
+**Recommendation: leave at `architecture/`.** Workstream-level architecture
+memos go in `architecture/` (see also the agenda-analysis memo from PR
+#32); operational OSPI docs (validator plan/review) live in
+`docs/ai/ospi/`.
+
+### O2 — Schema namespace
+
+OSPI tables go in a new `ospi_facts` Postgres schema in the same
+`qorvault` database (parallel to `agenda_runs`).
+**Recommendation: yes.** Keeps namespace isolation; same DB simplifies
+backups and credentials.
+
+### O3 — Year-format canonical form
+
+Canonical year format for storage and query.
+**Recommendation: full form `YYYY-YYYY` (e.g., `"2024-2025"`).** More
+human-readable; trivially convertible to short form for display.
+
+### O4 — Student-group taxonomy
+
+Should QorVault adopt OSPI's student-group taxonomy as-is, or canonicalize
+to a project-defined controlled vocabulary?
+**Recommendation: adopt OSPI's taxonomy as-is**, store the original
+string, and add a `student_group_canonical` column populated from a
+mapping table that lives in version control. Aliases don't get inferred by
+LLM.
+
+### O5 — Snapshot lifecycle
+
+Keep all historical snapshots forever, or evict after N years?
+**Recommendation: keep all, no eviction in V1.** Disk on Smeltor is
+adequate; historical answers must remain re-derivable.
+
+### O6 — Manifest reconciliation depth
+
+Spot-check (N random files) vs. full re-derive (all files) on every
+ingestion run.
+**Recommendation: full re-derive on every ingestion run.** Cost is
+bounded (stream-hash 586 MB; ~5–10 seconds); avoids any chance of silent
+drift.
+
+### O7 — District / school registry source
+
+Build the canonical registry from (a) profiling distinct codes across the
+corpus, (b) downloading OSPI's published district/school list, or (c) a
+manual hand-maintained file.
+**Recommendation: (a) primary, (b) optional cross-check.** Profile-derived
+gives us only codes present in the data; OSPI's published list adds codes
+that exist but appear with no facts. Avoid (c) — manual maintenance ages
+poorly.
+
+### O8 — First-ingestion target dataset
+
+Which dataset is the cleanest first target for end-to-end ingestion?
+**Recommendation: enrollment**, with attendance second. Enrollment has
+fewer suppression complications and is the denominator for many later
+metrics.
+
+### O9 — `download_ospi.py` audit
+
+Should we audit the existing download script before any ingestion, or
+trust the on-disk corpus as-is?
+**Recommendation: audit before ingestion.** A read-only review of the
+script is small and surfaces any pre-ingest transformations we'd
+otherwise be unable to detect after the fact.
+
+### O10 — Trust framing
+
+How do we present OSPI facts to readers downstream of the agenda renderer?
+**Recommendation: always present as "OSPI Report Card, [year]"** with a
+link or attribution. Never imply that a number originated with QorVault
+analysis.
+
+---
+
+## Top 5 risks (ranked)
+
+1. **R3 — district/school code stability across years.** The single
+   biggest source of silent join errors if not handled by a code-lifetime
+   registry. Mitigation: registry table is a Stage-0 deliverable in the
+   schema and record-identity design work.
+2. **R1 — suppression-convention divergence.** Conflating
+   "privacy-suppressed" with "not yet reported" produces wrong
+   percentages. Mitigation: use STC's suppression-pattern evidence before
+   any normalization, then lock the taxonomy in the schema design work.
+3. **R5 — multi-grain rows.** Aggregations that don't filter by grain
+   double-count. Mitigation: explicit grain enum column; aggregation
+   views filter by grain in the schema and ingestion design work.
+4. **R8 — `download_ospi.py` is unaudited.** Anything wrong upstream of
+   our corpus is invisible to manifest validation. Mitigation: audit
+   before any ingestion (decision O9).
+5. **R10 — trust boundary.** OSPI facts get treated as omniscient by
+   downstream consumers. Mitigation: every citation carries OSPI
+   attribution; renderer is required to surface it (decision O10).
+
+## Top 5 next implementation steps
+
+1. **Open: OSPI corpus profile — schema-lock (Stage 0 design).** Convert
+   STC's discovery profile into a Pydantic-versioned per-dataset profile
+   artifact with fixture format, profile-output schema, and gate criteria.
+2. **Open: OSPI authority and provenance model — OspiCitation contract.** Lock the
+   `OspiCitation` schema (Section 5/10). Pydantic + JSON schema.
+3. **Open: OSPI per-dataset schema and record-identity design.** Per-dataset
+   Pydantic schemas + the composite identity. Depends on the schema-locked
+   profile outputs.
+4. **Open: OSPI dev-only ingestion — table design and migration plan (docs only).**
+   Specifies the three-tier table layout and the migration plan.
+5. **Audit `download_ospi.py`** as a small standalone task before any
+   ingestion lands (decision O9). Read-only review; no execution.
+
+## Proposed staged issue backlog
+
+See Section 15 for the full table. Sequence: schema-lock profile, citation
+contract, schema/identity design, dev-only ingestion design, first-dataset
+ingestion, query/citation layer, SQL facts library, agenda evidence mapping,
+then CI hardening.
+Issue #27 runs in parallel with this stack at any point.
+
+## Plain-English owner decisions for Donald
+
+See Section 17 for the full set (O1–O10). The most consequential are O3
+(year format), O4 (student-group taxonomy), O7 (registry source), and O9
+(audit `download_ospi.py` first). The rest are routine.
+
+## Assumptions requiring owner approval
+
+- **A1.** The validator manifest is the single source of truth for "what
+  is in the corpus" and gates everything downstream. Confirm.
+- **A2.** OSPI tables live in the same `qorvault` Postgres database as
+  existing schema, under a new `ospi_facts` schema. (Decision O2.)
+- **A3.** Citations always include "OSPI Report Card, [year]" framing.
+  (Decision O10.)
+- **A4.** Dev DB is separate from any production DB (today, only dev
+  exists; production DB is theoretical). Any future production schema is
+  out of scope for this roadmap and requires its own design.
+- **A5.** Stage 1.1 CI expansion is best done after the first
+  OSPI ingestion lands so the CI scope reflects real code, not hypothetical
+  modules.
+- **A6.** The agenda-analysis worker (per the prior architecture memo) is
+  the first consumer of the OSPI query/citation layer. The OSPI roadmap
+  must therefore lock its citation contract before OSPI-to-agenda mapping
+  can ship.
+
+---
+
+## Safety attestation
+
+- **Docs-only artifact:** this memo records architecture decisions and
+  does not add runtime code, schema migrations, or ingestion paths.
+- **No real OSPI corpus access in this memo-authoring task:** no
+  `download_ospi.py` invocation, no validation against the real corpus, no
+  reading of any `research/ospi_data/*.json` or `docs/ospi_data/*.json`
+  file. Corpus totals quoted in this memo come from the companion STC
+  profile report, not direct corpus access by this memo.
+- **Companion profile boundary:** the separate STC profiling pass was
+  read-only and is included here as a companion evidence artifact. It did not
+  run `download_ospi.py`, did not write to any database, and did not modify
+  corpus files.
+- **No production access. No Framework. No database — no DDL applied,
+  no migrations, no queries.**
+- **No ingestion, indexing, embedding, deployment, promotion, or sync
+  triggered.**
+- **No live BoardDocs / Kent School District access — no scraping, no
+  downloads.**
+- **No staging, commit, push, branch creation, tag, merge, or PR
+  creation.** This memo file is uncommitted; Donald must explicitly
+  authorize a commit on a feature branch.
+- **No implementation authorization** — every issue listed in Section 15
+  requires its own approval, scope review, and PR.

--- a/docs/ai/ospi/ospi_corpus_profile_20260504T203334Z.md
+++ b/docs/ai/ospi/ospi_corpus_profile_20260504T203334Z.md
@@ -1,0 +1,842 @@
+# OSPI Corpus Profile
+
+Generated: 2026-05-04T20:37:22Z
+Corpus path: `research/ospi_data`
+
+## Safety Scope
+
+This was a read-only profiling pass. No ingestion occurred. No database writes occurred. No corpus files were modified. No OSPI scripts or `download_ospi.py` were run.
+
+## Inventory
+
+| file | shape | records | bytes | sha256 | mtime_utc | parse_error |
+| --- | --- | --- | --- | --- | --- | --- |
+| assessment.json | array | 155528 | 146852924 | eff989bffa224de7d220716a81f928efb5ee37cfed06a89ec641f9a95a052ae3 | 2026-03-04T06:04:56+00:00 |  |
+| attendance.json | array | 75204 | 52051015 | 1a01d33b42a7dba748064f5536701b9153b283f4ad9d30f31cf913fe3ad76aa0 | 2026-03-04T06:04:56+00:00 |  |
+| discipline.json | array | 74033 | 79338788 | 79b2530af55fb89b32a4a8fdefca2f35247d9d604b80546881bb3613478e5194 | 2026-03-04T06:04:56+00:00 |  |
+| enrollment.json | array | 4562 | 6530509 | 91700ea5e014686258eec47ce09321cbae0f0d091150b2e5dc16f166e1bfa881 | 2026-03-04T06:04:56+00:00 |  |
+| graduation.json | array | 9670 | 9010709 | 7df76f589fa707216f5ff3375448741c6c47998ff236d8b343b24a36ac980f13 | 2026-03-04T06:04:56+00:00 |  |
+| growth.json | array | 50665 | 42919067 | 17207359cc4001ccc4bd43008ab29a17b5232e0248eb125b30fe7812acc7c3d8 | 2026-03-04T06:04:56+00:00 |  |
+| sqss.json | array | 109011 | 77841214 | a991c6c0767b6b2d450be5f3e66d25f4f723121497a08c956cd97b2fdbab8a24 | 2026-03-04T06:04:56+00:00 |  |
+| teacher_demographics.json | array | 4745 | 4404885 | 8308483c658af073ee721bdc5596f5613b29feaf54d8a017c7699d38f3e97df2 | 2026-03-04T06:04:56+00:00 |  |
+| teacher_experience.json | array | 4602 | 3314081 | 79a0037878611517f18f44bc2ee2ef56e7f3dba1f1bff7f6e4e9da0cd9190dcf | 2026-03-04T06:04:56+00:00 |  |
+| wakids.json | array | 210202 | 163941382 | d727602ff1f85276fe4d1e9ebb942f545e255f08d48c71c4d4bfb35c3a5bd93e | 2026-03-04T06:04:56+00:00 |  |
+
+Total bytes: 586,204,574
+Reference bytes: 586,204,574
+Byte delta: 0
+Total records: 698,222
+Reference records: 698,222
+Record delta: 0
+
+Expected files present: assessment.json, attendance.json, discipline.json, enrollment.json, graduation.json, growth.json, sqss.json, teacher_demographics.json, teacher_experience.json, wakids.json
+Expected files missing: none
+Unexpected JSON files: none
+
+## Record Counts
+
+| dataset | records |
+| --- | --- |
+| assessment.json | 155,528 |
+| attendance.json | 75,204 |
+| discipline.json | 74,033 |
+| enrollment.json | 4,562 |
+| graduation.json | 9,670 |
+| growth.json | 50,665 |
+| sqss.json | 109,011 |
+| teacher_demographics.json | 4,745 |
+| teacher_experience.json | 4,602 |
+| wakids.json | 210,202 |
+
+## Schema Summaries
+
+| dataset | top_fields | nested_paths | sample fields | common patterns |
+| --- | --- | --- | --- | --- |
+| assessment.json | 46 | 0 | county, dataasof, districtcode, districtname, districtorganizationid, esdname, esdorganizationid, gradelevel, organizationlevel, schoolname, schoolyear, studentgroup, studentgrouptype, testadministration | schoolyear, organizationlevel, districtcode, districtname, schoolcode, schoolname |
+| attendance.json | 27 | 0 | county, dataasof, districtcode, districtname, districtorganizationid, esdname, gradelevel, organizationlevel, schoolname, schoolyear, studentgroup, studentgrouptype, currentschooltype, schoolcode | schoolyear, organizationlevel, districtcode, districtname, schoolcode, schoolname |
+| discipline.json | 29 | 0 | county, dateextracted, disciplinedatnotes, disciplinedenominator, disciplinenumerator, disciplinerate, districtcode, districtname, districtorganizationid, esdname, esdorganizationid, gradelevel, organizationlevel, rateexcluded10daysormore | schoolyear, organizationlevel, districtcode, districtname, schoolcode, schoolname |
+| enrollment.json | 49 | 0 | all_students, american_indian_alaskan_native, asian, black_african_american, county, dataasof, districtcode, districtname, districtorganizationid, english_language_learners, esdname, esdorganizationid, female, gender_x | schoolyear, organizationlevel, districtcode, districtname, schoolcode, schoolname |
+| graduation.json | 35 | 0 | cohort, county, dataasof, districtcode, districtname, districtorganizationid, esdname, esdorganizationid, organizationlevel, schoolname, schoolyear, studentgroup, studentgrouptype, schoolcode | schoolyear, organizationlevel, districtcode, districtname, schoolcode, schoolname |
+| growth.json | 27 | 0 | county, dataasof, districtcode, districtname, districtorganizationid, esdname, esdorganizationid, gradelevel, organizationlevel, schoolname, schoolyear, studentgroup, studentgrouptype, subject | schoolyear, organizationlevel, districtcode, districtname, schoolcode, schoolname |
+| sqss.json | 50 | 0 | county, dataasof, districtcode, districtname, districtorganizationid, esdname, gradelevel, organizationlevel, schoolname, schoolyear, studentgroup, studentgrouptype, currentschooltype, schoolcode | schoolyear, organizationlevel, districtcode, districtname, schoolcode, schoolname |
+| teacher_demographics.json | 27 | 0 | avgyearsexperience, county, dataasof, demographiccategory, demographiccategoryid, demographiccategorytype, esdname, esdorganizationid, iseevalidated, leacode, leaname, leaorganizationid, ma_count, ma_percent | schoolyear, organizationlevel, schoolcode, schoolname |
+| teacher_experience.json | 21 | 0 | county, dataasof, esdname, esdorganizationid, experiencebin, iseevalidated, leacode, leaname, leaorganizationid, organizationid, organizationlevel, organizationlevelid, organizationname, rowid | schoolyear, organizationlevel, schoolcode, schoolname |
+| wakids.json | 23 | 0 | county, dataasof, districtname, districtorganizationid, domain, esdname, esdorganizationid, measure, organizationid, organizationlevel, schoolname, schoolyear, studentgroup, studentgrouptype | schoolyear, organizationlevel, districtname, schoolname |
+
+### assessment.json
+
+| field | coverage | types | distinct_cap | overflow | examples |
+| --- | --- | --- | --- | --- | --- |
+| county | 100.0% | str:155528 | 1 | no | 'King' |
+| dataasof | 100.0% | str:155528 | 5 | no | '2022-09-09T00:00:00.000'; '9/8/2023'; '2023-10-27 15:04:41.483' |
+| districtcode | 100.0% | str:155528 | 1 | no | '17415' |
+| districtname | 100.0% | str:155528 | 1 | no | 'Kent School District' |
+| districtorganizationid | 100.0% | str:155528 | 1 | no | '100117' |
+| esdname | 100.0% | str:155528 | 1 | no | 'Puget Sound Educational Service District 121' |
+| esdorganizationid | 100.0% | str:155528 | 1 | no | '100006' |
+| gradelevel | 100.0% | str:155528 | 14 | no | 'All Grades'; 'KG'; '01' |
+| organizationlevel | 100.0% | str:155528 | 2 | no | 'School'; 'District' |
+| schoolname | 100.0% | str:155528 | 48 | no | 'Grass Lake Elementary School'; 'Horizon Elementary School'; 'Individualized Graduation & Degree Program' |
+| schoolyear | 100.0% | str:155528 | 10 | no | '2020-21'; '2018-19'; '2017-18' |
+| studentgroup | 100.0% | str:155528 | 30 | no | 'Non-Low Income'; 'Female'; 'Male' |
+| studentgrouptype | 100.0% | str:155528 | 11 | no | 'FRL'; 'Gender'; 'homeless' |
+| testadministration | 100.0% | str:155528 | 8 | no | 'SBAC'; 'ELPA'; 'WCAS' |
+| testsubject | 100.0% | str:155528 | 7 | no | 'Math'; 'ELPA'; 'ELA' |
+| schoolorganizationid | 93.54% | str:145487 | 48 | no | '101591'; '101605'; '105491' |
+| currentschooltype | 92.94% | str:144551 | 4 | no | 'P'; 'R'; 'A' |
+| schoolcode | 92.94% | str:144551 | 47 | no | '3708'; '4345'; '5275' |
+| percentmetstandard | 73.69% | str:114615 | 935 | no | '67.7%'; '<10%'; '85.5%' |
+| suppression | 73.69% | str:114615 | 23 | no | 'None'; '<10%'; 'N<10' |
+| percentlevel1 | 57.53% | str:89476 | 5000 | yes | '0.0977443609022'; '0.0560747663551'; '0.03738317757' |
+| percentlevel2 | 57.53% | str:89476 | 5000 | yes | '0.2030075187969'; '0.0654205607476'; '0.1588785046728' |
+| percentlevel3 | 57.53% | str:89476 | 5000 | yes | '0.2932330827067'; '0.2757009345794'; '0.214953271028' |
+| percentlevel4 | 57.53% | str:89476 | 5000 | yes | '0.3834586466165'; '0.5794392523364'; '0.5747663551401' |
+| percent_no_score | 48.76% | str:75836 | 5000 | yes | '0.0225563909774'; '0.0233644859813'; '0.0140186915887' |
+| count_of_students_expected | 45.62% | str:70949 | 1978 | no | '133'; '214'; '54' |
+| percentmettestedonly | 39.57% | str:61542 | 5000 | yes | '0.6923076923076'; '0.8755980861244'; '0.8009478672985' |
+| count_of_students_expected_to_test_including_previously_passed | 38.77% | str:60299 | 1786 | no | '133'; '214'; '54' |
+| countmetstandard | 30.0% | str:46659 | 1243 | no | '90'; '183'; '169' |
+| dat | 26.31% | str:40913 | 106 | no | 'N<10'; 'None'; 'Cross Student Group - N<10' |
+| percent_consistent_grade_level_knowledge_and_above | 17.47% | str:27166 | 1690 | no | 'N<10'; '39.3%'; '35.7%' |
+| percent_foundational_grade | 17.34% | str:26964 | 1611 | no | 'N<10'; '52.60%'; '34.70%' |
+| test_administration_group | 17.34% | str:26964 | 3 | no | 'AIM'; 'SBAC'; 'WCAS' |
+| count_consistent_grade_level_knowledge_and_above | 12.3% | str:19137 | 614 | no | 'NULL'; '11'; '5' |
+| percent_consistent_grade | 8.84% | str:13747 | 779 | no | '15.1%'; 'N<10'; '27.4%' |
+| percent_consistent_tested_only | 8.77% | str:13640 | 2351 | no | 'NULL'; '0.3928571428571'; '0.3571428571428' |
+| percentnoscore | 8.77% | str:13640 | 1353 | no | 'NULL'; '0.0000000000000'; '0.0109170305676' |
+| percentparticipation | 8.77% | str:13640 | 1353 | no | 'NULL'; '1.0000000000000'; '0.9890829694323' |
+| percent_participation | 8.69% | str:13509 | 2810 | no | '0.980237154'; '0.984251969'; '0.980988593' |
+| count_foundational_grade | 7.27% | str:11303 | 756 | no | '133'; '88'; '151' |
+| count_of_students_expected_1 | 6.65% | str:10341 | 859 | no | '253'; '254'; '263' |
+| percent_taking_alternative_assessment | 5.18% | str:8055 | 898 | no | '0.024193'; '0.024'; '0.015503' |
+| percent_taking_alternative | 5.12% | str:7966 | 939 | no | '0.007434'; '0.007575'; '0.007936' |
+| percent_met_tested_only | 4.61% | str:7170 | 2363 | no | '0.266129032'; '0.132'; '0.310077519' |
+| percent_consistent_tested | 4.58% | str:7124 | 2360 | no | '0.1561338289962'; '0.2878787878787'; '0.2936507936507' |
+| count_consistent_grade_level | 3.31% | str:5153 | 415 | no | '42'; '76'; '74' |
+
+### attendance.json
+
+| field | coverage | types | distinct_cap | overflow | examples |
+| --- | --- | --- | --- | --- | --- |
+| county | 100.0% | str:75204 | 1 | no | 'King' |
+| dataasof | 100.0% | str:75204 | 5 | no | '2023-07-11T00:00:00.000'; '2023-06-21T00:00:00.000'; '2023-06-21' |
+| districtcode | 100.0% | str:75204 | 1 | no | '17415' |
+| districtname | 100.0% | str:75204 | 1 | no | 'Kent School District' |
+| districtorganizationid | 100.0% | str:75204 | 1 | no | '100117' |
+| esdname | 100.0% | str:75204 | 1 | no | 'Puget Sound Educational Service District 121' |
+| gradelevel | 100.0% | str:75204 | 15 | no | '9'; '1'; '10' |
+| organizationlevel | 100.0% | str:75204 | 2 | no | 'District'; 'School' |
+| schoolname | 100.0% | str:75204 | 48 | no | 'District Total'; 'Grass Lake Elementary School'; 'Cedar Valley Elementary School' |
+| schoolyear | 100.0% | str:75204 | 10 | no | '2014-15'; '2015-16'; '2016-17' |
+| studentgroup | 100.0% | str:75204 | 39 | no | 'Migrant'; 'All Students'; 'English Language Learners' |
+| studentgrouptype | 100.0% | str:75204 | 24 | no | 'Migrant'; 'AllStudents'; 'EnglishLearner' |
+| currentschooltype | 94.61% | str:71147 | 4 | no | 'P'; 'A'; 'R' |
+| schoolcode | 94.61% | str:71147 | 47 | no | '3708'; '3676'; '4345' |
+| schoolorganizationid | 94.61% | str:71147 | 47 | no | '101591'; '101587'; '101605' |
+| esdorganizationid | 89.82% | str:67551 | 1 | no | '100006' |
+| measures | 59.37% | str:44652 | 1 | no | 'Regular Attendance' |
+| suppression | 59.37% | str:44652 | 17 | no | 'Suppressed: N<10'; 'No Suppression'; 'Suppressed: >95%' |
+| denominator | 46.94% | str:35300 | 1917 | no | '41'; '44'; '51' |
+| numerator | 45.68% | str:34354 | 1782 | no | '37'; '46'; '54' |
+| measure | 40.63% | str:30552 | 1 | no | 'Regular Attendance' |
+| suppressionreason | 20.09% | str:15111 | 19 | no | 'No Suppression'; 'Suppressed: >92%'; 'Suppressed: >94%' |
+| datreason | 10.36% | str:7788 | 85 | no | 'None'; 'Top/Bottom Range: >72.7%'; 'Top/Bottom Range: >76.9%' |
+| dat_reason | 10.18% | str:7653 | 75 | no | 'None'; 'Cross Student Group - N<10'; 'Cross Grade Level - N<10' |
+| label | 10.18% | str:7653 | 637 | no | '70.2%'; '60.8%'; '50.0%' |
+| organizationname | 10.18% | str:7653 | 45 | no | 'Canyon Ridge Middle School'; 'Carriage Crest Elementary School'; 'Cedar Heights Middle School' |
+| percent | 7.74% | str:5821 | 1677 | no | '0.7018'; '0.608'; '0.6076' |
+
+### discipline.json
+
+| field | coverage | types | distinct_cap | overflow | examples |
+| --- | --- | --- | --- | --- | --- |
+| county | 100.0% | str:74033 | 1 | no | 'King' |
+| dateextracted | 100.0% | str:74033 | 10 | no | '2023-09-09T23:32:31.310Z'; '2023-09-10T01:00:19.500Z'; '2023-09-10T02:11:21.683Z' |
+| disciplinedatnotes | 100.0% | str:74033 | 6 | no | 'None'; 'Top/Bottom Range'; 'N<10' |
+| disciplinedenominator | 100.0% | str:74033 | 1778 | no | '74'; '*'; '443' |
+| disciplinenumerator | 100.0% | str:74033 | 297 | no | '4'; '*'; '5' |
+| disciplinerate | 100.0% | str:74033 | 2506 | no | '5.41%'; '<4.4%'; '<3.8%' |
+| districtcode | 100.0% | str:74033 | 1 | no | '17415' |
+| districtname | 100.0% | str:74033 | 1 | no | 'Kent School District' |
+| districtorganizationid | 100.0% | str:74033 | 1 | no | '100117' |
+| esdname | 100.0% | str:74033 | 1 | no | 'Puget Sound Educational Service District 121' |
+| esdorganizationid | 100.0% | str:74033 | 1 | no | '100006' |
+| gradelevel | 100.0% | str:74033 | 14 | no | 'Kindergarten'; '1st Grade'; '2nd Grade' |
+| organizationlevel | 100.0% | str:74033 | 2 | no | 'School'; 'District' |
+| rateexcluded10daysormore | 100.0% | str:74033 | 993 | no | '0.00%'; 'Top/Bottom Range'; 'N<10' |
+| rateexcluded1dayorless | 100.0% | str:74033 | 1282 | no | '75.00%'; 'Top/Bottom Range'; '80.00%' |
+| rateexcluded2to3days | 100.0% | str:74033 | 1226 | no | '25.00%'; 'Top/Bottom Range'; '20.00%' |
+| rateexcluded4to5days | 100.0% | str:74033 | 1087 | no | '0.00%'; 'Top/Bottom Range'; 'N<10' |
+| rateexcluded6to10days | 100.0% | str:74033 | 1022 | no | '0.00%'; 'Top/Bottom Range'; 'N<10' |
+| schoolname | 100.0% | str:74033 | 48 | no | 'Carriage Crest Elementary School'; 'Cedar Heights Middle School'; 'Cedar Valley Elementary School' |
+| schoolyear | 100.0% | str:74033 | 10 | no | '2014-15'; '2015-16'; '2016-17' |
+| student_group | 100.0% | str:74033 | 29 | no | 'Non-Highly Capable'; 'All Students'; 'American Indian/ Alaskan Native' |
+| currentschooltype | 94.74% | str:70140 | 4 | no | 'P'; 'R'; 'A' |
+| schoolcode | 94.74% | str:70140 | 47 | no | '4353'; '4440'; '3676' |
+| schoolorganizationid | 94.74% | str:70140 | 47 | no | '101606'; '101610'; '101587' |
+| excluded10daysormore | 92.16% | str:68232 | 94 | no | '0'; '*'; '5' |
+| excluded1dayorless | 92.16% | str:68232 | 139 | no | '3'; '*'; '4' |
+| excluded2to3days | 92.16% | str:68232 | 181 | no | '1'; '*'; '9' |
+| excluded4to5days | 92.16% | str:68232 | 109 | no | '0'; '*'; '7' |
+| excluded6to10days | 92.16% | str:68232 | 108 | no | '0'; '*'; '3' |
+
+### enrollment.json
+
+| field | coverage | types | distinct_cap | overflow | examples |
+| --- | --- | --- | --- | --- | --- |
+| all_students | 100.0% | str:4562 | 730 | no | '2198'; '2135'; '2035' |
+| american_indian_alaskan_native | 100.0% | str:4562 | 28 | no | '13'; '9'; '4' |
+| asian | 100.0% | str:4562 | 343 | no | '363'; '395'; '411' |
+| black_african_american | 100.0% | str:4562 | 253 | no | '267'; '210'; '228' |
+| county | 100.0% | str:4562 | 1 | no | 'King' |
+| dataasof | 100.0% | str:4562 | 4 | no | '2023-12-22T00:00:00.000'; '2024-06-18T00:00:00.000'; '2025-06-02T00:00:00.000' |
+| districtcode | 100.0% | str:4562 | 1 | no | '17415' |
+| districtname | 100.0% | str:4562 | 1 | no | 'Kent School District' |
+| districtorganizationid | 100.0% | str:4562 | 1 | no | '100117' |
+| english_language_learners | 100.0% | str:4562 | 400 | no | '172'; '122'; '128' |
+| esdname | 100.0% | str:4562 | 1 | no | 'Puget Sound Educational Service District 121' |
+| esdorganizationid | 100.0% | str:4562 | 1 | no | '100006' |
+| female | 100.0% | str:4562 | 492 | no | '1055'; '1030'; '968' |
+| gender_x | 100.0% | str:4562 | 20 | no | '0'; '1'; '4' |
+| gradelevel | 100.0% | str:4562 | 16 | no | '10th Grade'; '11th Grade'; '12th Grade' |
+| highly_capable | 100.0% | str:4562 | 232 | no | '0'; '1'; '37' |
+| hispanic_latino_of_any_race | 100.0% | str:4562 | 379 | no | '443'; '359'; '304' |
+| homeless | 100.0% | str:4562 | 70 | no | '22'; '23'; '18' |
+| low_income | 100.0% | str:4562 | 620 | no | '1164'; '1023'; '928' |
+| male | 100.0% | str:4562 | 509 | no | '1143'; '1105'; '1067' |
+| migrant | 100.0% | str:4562 | 21 | no | '6'; '2'; '5' |
+| military_parent | 100.0% | str:4562 | 45 | no | '0'; '1'; '3' |
+| mobile | 100.0% | str:4562 | 135 | no | '136'; '101'; '118' |
+| non_english_language_learners | 100.0% | str:4562 | 687 | no | '2026'; '2013'; '1907' |
+| non_highly_capable | 100.0% | str:4562 | 736 | no | '2198'; '2135'; '2035' |
+| non_homeless | 100.0% | str:4562 | 736 | no | '2176'; '2112'; '2017' |
+| non_low_income | 100.0% | str:4562 | 568 | no | '1034'; '1112'; '1107' |
+| non_migrant | 100.0% | str:4562 | 725 | no | '2192'; '2133'; '2033' |
+| non_military_parent | 100.0% | str:4562 | 742 | no | '2198'; '2135'; '2035' |
+| non_mobile | 100.0% | str:4562 | 719 | no | '2062'; '2034'; '1917' |
+| non_section_504 | 100.0% | str:4562 | 728 | no | '2093'; '2033'; '1947' |
+| organizationlevel | 100.0% | str:4562 | 2 | no | 'District'; 'School' |
+| schoolname | 100.0% | str:4562 | 49 | no | 'District Total'; 'Fairwood Elementary School'; 'Soos Creek Elementary School' |
+| schoolyear | 100.0% | str:4562 | 12 | no | '2014-15'; '2015-16'; '2016-17' |
+| section_504 | 100.0% | str:4562 | 157 | no | '105'; '102'; '88' |
+| students_with_disabilities | 100.0% | str:4562 | 255 | no | '209'; '176'; '200' |
+| students_without_disabilities | 100.0% | str:4562 | 704 | no | '1989'; '1959'; '1835' |
+| two_or_more_races | 100.0% | str:4562 | 204 | no | '187'; '198'; '121' |
+| white | 100.0% | str:4562 | 462 | no | '877'; '923'; '914' |
+| currentschooltype | 95.27% | str:4346 | 5 | no | 'P'; 'A'; 'S' |
+| schoolcode | 95.27% | str:4346 | 48 | no | '3678'; '3707'; '3708' |
+| schoolorganizationid | 95.27% | str:4346 | 48 | no | '101589'; '101590'; '101591' |
+| fostercare | 86.06% | str:3926 | 22 | no | '10'; '0'; '14' |
+| native_hawaiian_pacific_islander | 86.06% | str:3926 | 104 | no | '48'; '41'; '44' |
+| non_fostercare | 86.06% | str:3926 | 190 | no | '2188'; '2128'; '2028' |
+| dat | 32.35% | str:1476 | 3 | no | 'DAT Applied: Foster Care - N < 10'; 'DAT Applied: > 95%'; 'DAT Applied: N < 10' |
+| foster_care | 13.94% | str:636 | 3 | no | '0'; '52'; '42' |
+| native_hawaiian_other_pacific | 13.94% | str:636 | 62 | no | '49'; '65'; '68' |
+| non_foster_care | 13.94% | str:636 | 27 | no | '1936'; '1945'; '2289' |
+
+### graduation.json
+
+| field | coverage | types | distinct_cap | overflow | examples |
+| --- | --- | --- | --- | --- | --- |
+| cohort | 100.0% | str:9670 | 6 | no | 'Five Year'; 'Four Year'; 'Seven Year' |
+| county | 100.0% | str:9670 | 1 | no | 'King' |
+| dataasof | 100.0% | str:9670 | 4 | no | '2024-01-19T00:00:00.000'; '2024-01-19'; '2024-11-27T00:00:00.000' |
+| districtcode | 100.0% | str:9670 | 1 | no | '17415' |
+| districtname | 100.0% | str:9670 | 1 | no | 'Kent School District' |
+| districtorganizationid | 100.0% | str:9670 | 1 | no | '100117' |
+| esdname | 100.0% | str:9670 | 1 | no | 'Puget Sound Educational Service District 121' |
+| esdorganizationid | 100.0% | str:9670 | 1 | no | '100006' |
+| organizationlevel | 100.0% | str:9670 | 2 | no | 'School'; 'District' |
+| schoolname | 100.0% | str:9670 | 13 | no | 'Individualized Graduation & Degree Program'; 'Kent-Meridian High School'; 'Kent Mountain View Academy (Closed after 2020-2021 school year)' |
+| schoolyear | 100.0% | str:9670 | 11 | no | '2020-21'; '2019-20'; '2018-19' |
+| studentgroup | 100.0% | str:9670 | 30 | no | 'Non Section 504'; 'Section 504'; 'All Students' |
+| studentgrouptype | 100.0% | str:9670 | 12 | no | '504'; 'All'; 'ELL' |
+| schoolcode | 98.8% | str:9554 | 13 | no | '5275'; '2797'; '3014' |
+| schoolorganizationid | 98.8% | str:9554 | 13 | no | '105491'; '101574'; '101576' |
+| graduationrate | 95.18% | str:9204 | 2564 | no | '0.165'; '0.066'; '0.1556420233463' |
+| graduate | 91.4% | str:8838 | 660 | no | 'NULL'; '40'; '35' |
+| transferout | 91.4% | str:8838 | 211 | no | 'NULL'; '10'; '15' |
+| year4dropout | 91.33% | str:8832 | 118 | no | 'NULL'; '69'; '58' |
+| year3dropout | 91.3% | str:8829 | 48 | no | 'NULL'; '26'; '20' |
+| year1dropout | 91.02% | str:8802 | 38 | no | 'NULL'; '4'; '1' |
+| year2dropout | 90.98% | str:8798 | 36 | no | 'NULL'; '2'; '3' |
+| year5dropout | 90.81% | str:8781 | 100 | no | 'NULL'; '60'; '77' |
+| year6dropout | 90.57% | str:8758 | 81 | no | 'NULL'; '27'; '49' |
+| year7dropout | 90.39% | str:8741 | 56 | no | 'NULL'; '31'; '40' |
+| finalcohort | 82.16% | str:7945 | 685 | no | 'NULL'; '257'; '282' |
+| transferin | 82.16% | str:7945 | 228 | no | 'NULL'; '37'; '42' |
+| beggininggrade9 | 79.9% | str:7726 | 648 | no | 'NULL'; '230'; '255' |
+| suppression | 70.69% | str:6836 | 161 | no | 'Cross Group'; 'No DAT'; '<1.54%' |
+| continuing | 29.94% | str:2895 | 62 | no | 'NULL'; '0'; '33' |
+| dropout | 29.94% | str:2895 | 144 | no | 'NULL'; '203'; '140' |
+| dat | 29.31% | str:2834 | 120 | no | 'Cross Group'; 'No DAT'; '<17.6%' |
+| beginninggrade9 | 11.5% | str:1112 | 181 | no | 'NULL'; '218'; '268' |
+| final_cohort | 9.23% | str:893 | 196 | no | 'NULL'; '234'; '192' |
+| transferredin | 9.23% | str:893 | 87 | no | 'NULL'; '30'; '23' |
+
+### growth.json
+
+| field | coverage | types | distinct_cap | overflow | examples |
+| --- | --- | --- | --- | --- | --- |
+| county | 100.0% | str:50665 | 1 | no | 'King' |
+| dataasof | 100.0% | str:50665 | 4 | no | '2019-12-06T00:00:00.000'; '2023-12-11T00:00:00.000'; '2024-08-30T00:00:00.000' |
+| districtcode | 100.0% | str:50665 | 1 | no | '17415' |
+| districtname | 100.0% | str:50665 | 1 | no | 'Kent School District' |
+| districtorganizationid | 100.0% | str:50665 | 1 | no | '100117' |
+| esdname | 100.0% | str:50665 | 1 | no | 'Puget Sound Educational Service District 121' |
+| esdorganizationid | 100.0% | str:50665 | 1 | no | '100006' |
+| gradelevel | 100.0% | str:50665 | 12 | no | '6th Grade'; 'All Grades'; '4th Grade' |
+| organizationlevel | 100.0% | str:50665 | 2 | no | 'School'; 'District' |
+| schoolname | 100.0% | str:50665 | 40 | no | 'Grass Lake Elementary School'; 'Carriage Crest Elementary School'; 'Cedar Heights Middle School' |
+| schoolyear | 100.0% | str:50665 | 8 | no | '2014-15'; '2018-19'; '2017-18' |
+| studentgroup | 100.0% | str:50665 | 35 | no | 'Non-Low Income'; 'Non Migrant'; 'Military Parent' |
+| studentgrouptype | 100.0% | str:50665 | 12 | no | 'Low Income'; 'Migrant'; 'Military' |
+| subject | 100.0% | str:50665 | 2 | no | 'English Language Arts'; 'Math' |
+| schoolcode | 97.24% | str:49265 | 40 | no | '3708'; '4353'; '4440' |
+| schoolorganizationid | 97.24% | str:49265 | 40 | no | '101591'; '101606'; '101610' |
+| currentschooltype | 95.12% | str:48193 | 2 | no | 'P'; 'A' |
+| mediansgp | 82.63% | str:41864 | 176 | no | '58.5'; '49'; '55' |
+| percenthighgrowth | 82.63% | str:41864 | 3468 | no | '0.378'; '0.327'; '0.362' |
+| percentlowgrowth | 82.63% | str:41864 | 3476 | no | '0.284'; '0.32'; '0.261' |
+| percenttypicalgrowth | 82.63% | str:41864 | 2863 | no | '0.338'; '0.353'; '0.377' |
+| numberhighgrowth | 75.07% | str:38035 | 767 | no | '56'; '49'; '50' |
+| numberlowgrowth | 75.07% | str:38035 | 811 | no | '42'; '48'; '36' |
+| numbertypicalgrowth | 75.07% | str:38035 | 758 | no | '50'; '53'; '52' |
+| studentcount | 75.07% | str:38035 | 1358 | no | '148'; '150'; '138' |
+| suppression | 41.11% | str:20826 | 7 | no | 'Suppressed: N<10'; 'Suppressed: Cross Group'; 'Suppressed: Cross Grade' |
+| datreason | 28.66% | str:14521 | 4 | no | 'NULL'; 'N<10'; 'Cross Group' |
+
+### sqss.json
+
+| field | coverage | types | distinct_cap | overflow | examples |
+| --- | --- | --- | --- | --- | --- |
+| county | 100.0% | str:109011 | 1 | no | 'King' |
+| dataasof | 100.0% | str:109011 | 5 | no | '2023-07-11T00:00:00.000'; '2023-06-21T00:00:00.000'; '2023-06-21' |
+| districtcode | 100.0% | str:109011 | 1 | no | '17415' |
+| districtname | 100.0% | str:109011 | 1 | no | 'Kent School District' |
+| districtorganizationid | 100.0% | str:109011 | 1 | no | '100117' |
+| esdname | 100.0% | str:109011 | 1 | no | 'Puget Sound Educational Service District 121' |
+| gradelevel | 100.0% | str:109011 | 15 | no | '11'; '9'; '1' |
+| organizationlevel | 100.0% | str:109011 | 2 | no | 'District'; 'School' |
+| schoolname | 100.0% | str:109011 | 48 | no | 'District Total'; 'Grass Lake Elementary School'; 'Cedar Valley Elementary School' |
+| schoolyear | 100.0% | str:109011 | 10 | no | '2014-15'; '2015-16'; '2016-17' |
+| studentgroup | 100.0% | str:109011 | 39 | no | 'Foster Care'; 'Migrant'; 'All Students' |
+| studentgrouptype | 100.0% | str:109011 | 24 | no | 'Foster'; 'Migrant'; 'AllStudents' |
+| currentschooltype | 94.47% | str:102985 | 4 | no | 'P'; 'A'; 'R' |
+| schoolcode | 94.47% | str:102985 | 47 | no | '3708'; '3676'; '4345' |
+| schoolorganizationid | 94.47% | str:102985 | 47 | no | '101591'; '101587'; '101605' |
+| esdorganizationid | 89.64% | str:97719 | 1 | no | '100006' |
+| measures | 59.41% | str:64762 | 3 | no | 'Dual Credit'; 'Regular Attendance'; 'Ninth Grade on Track' |
+| suppression | 59.41% | str:64762 | 26 | no | 'Suppressed: N<10'; 'No Suppression'; 'Suppressed: >95%' |
+| denominator | 41.0% | str:44695 | 2218 | no | '41'; '44'; '51' |
+| measure | 40.59% | str:44249 | 3 | no | 'Regular Attendance'; 'Dual Credit'; 'Ninth Grade on Track' |
+| numerator | 40.13% | str:43749 | 2079 | no | '37'; '46'; '54' |
+| suppressionreason | 19.91% | str:21705 | 26 | no | 'No Suppression'; 'Suppressed: >92%'; 'Suppressed: >94%' |
+| dat_reason | 10.36% | str:11292 | 114 | no | 'No Students'; 'None'; 'Cross Student Group - N<10' |
+| organizationname | 10.36% | str:11292 | 45 | no | 'Canyon Ridge Middle School'; 'Carriage Crest Elementary School'; 'Cedar Heights Middle School' |
+| label | 10.35% | str:11283 | 748 | no | 'No Students'; '70.2%'; '60.8%' |
+| datreason | 10.32% | str:11252 | 133 | no | 'None'; 'Top/Bottom Range: >72.7%'; 'Top/Bottom Range: >76.9%' |
+| percent | 6.45% | str:7026 | 2071 | no | '0.7018'; '0.608'; '0.6076' |
+| percenttakingctetechprep | 6.35% | str:6922 | 3977 | no | '0.1'; '0.05'; '0.2752293577981' |
+| percenttakingcollegeinth | 6.26% | str:6823 | 3255 | no | '0.1'; '0.05'; '0.03' |
+| percenttakingap | 6.23% | str:6791 | 3294 | no | '0.1'; '0.05'; '0.03' |
+| percenttakingrunningstart | 6.11% | str:6660 | 2493 | no | '0.1'; '0.05'; '0.03' |
+| percenttakingib | 5.97% | str:6504 | 1205 | no | '0.1'; '0.05'; '0.03' |
+| percenttakingcambridge | 5.87% | str:6397 | 10 | no | '0.1'; '0.05'; '0.03' |
+| numbertakingctetechprep | 4.33% | str:4722 | 939 | no | '30'; '152'; '324' |
+| numbertakingap | 3.28% | str:3572 | 626 | no | '162'; '100'; '103' |
+| numbertakingcollegeinthe | 3.24% | str:3537 | 575 | no | '155'; '111'; '13' |
+| numbertakingrunningstart | 2.5% | str:2723 | 492 | no | '12'; '8'; '82' |
+| apcoursenumber | 1.51% | str:1648 | 166 | no | '0'; '615'; '356' |
+| cambridgecoursenumber | 1.51% | str:1648 | 1 | no | '0' |
+| cihscoursenumber | 1.51% | str:1648 | 230 | no | '0'; '7'; '3' |
+| ctecoursenumber | 1.51% | str:1648 | 301 | no | '0'; '13'; '4' |
+| ibcoursenumber | 1.51% | str:1648 | 53 | no | '0'; '81'; '153' |
+| runningstartcoursenumber | 1.51% | str:1648 | 159 | no | '0'; '3'; '17' |
+| numbertakingib | 1.05% | str:1148 | 249 | no | '25'; '24'; '3' |
+| apcoursepercent | 0.82% | str:899 | 245 | no | '0.031'; '0.034'; '0.1' |
+| cambridgecoursepercent | 0.82% | str:899 | 100 | no | '0.031'; '0.034'; '0.1' |
+| cihscoursepercent | 0.82% | str:899 | 375 | no | '0.031'; '0.034'; '0.1' |
+| ctecoursepercent | 0.82% | str:899 | 362 | no | '0.031'; '0.034'; '0.1' |
+| ibcoursepercent | 0.82% | str:899 | 154 | no | '0.031'; '0.034'; '0.1' |
+| runningstartcoursepercent | 0.82% | str:899 | 289 | no | '0.031'; '0.034'; '0.1' |
+
+### teacher_demographics.json
+
+| field | coverage | types | distinct_cap | overflow | examples |
+| --- | --- | --- | --- | --- | --- |
+| avgyearsexperience | 100.0% | str:4745 | 280 | no | '12.3'; '11.9'; 'NULL' |
+| county | 100.0% | str:4745 | 1 | no | 'King' |
+| dataasof | 100.0% | str:4745 | 2 | no | '2025-12-11'; '2025-12-16' |
+| demographiccategory | 100.0% | str:4745 | 13 | no | 'All'; 'Female'; 'Gender X' |
+| demographiccategoryid | 100.0% | str:4745 | 13 | no | '0'; '9'; '10' |
+| demographiccategorytype | 100.0% | str:4745 | 3 | no | 'All'; 'Gender'; 'RaceEthnicity' |
+| esdname | 100.0% | str:4745 | 1 | no | 'Puget Sound Educational Service District 121' |
+| esdorganizationid | 100.0% | str:4745 | 1 | no | '100006' |
+| iseevalidated | 100.0% | str:4745 | 2 | no | '1'; '0' |
+| leacode | 100.0% | str:4745 | 1 | no | '17415' |
+| leaname | 100.0% | str:4745 | 1 | no | 'Kent School District' |
+| leaorganizationid | 100.0% | str:4745 | 1 | no | '100117' |
+| ma_count | 100.0% | str:4745 | 109 | no | '1176'; '836'; '0' |
+| ma_percent | 100.0% | str:4745 | 331 | no | '0.769'; '0.772'; 'NULL' |
+| organizationid | 100.0% | str:4745 | 49 | no | '100117'; '101569'; '101571' |
+| organizationlevel | 100.0% | str:4745 | 2 | no | 'LEA'; 'School' |
+| organizationlevelid | 100.0% | str:4745 | 2 | no | '3'; '4' |
+| organizationname | 100.0% | str:4745 | 49 | no | 'Kent School District'; 'Regional Justice Center'; 'Meridian Elementary School' |
+| rowid | 100.0% | str:4745 | 4745 | no | '260859'; '260860'; '260861' |
+| schoolcode | 100.0% | str:4745 | 49 | no | 'NULL'; '1807'; '2565' |
+| schoolname | 100.0% | str:4745 | 49 | no | 'NULL'; 'Regional Justice Center'; 'Meridian Elementary School' |
+| schoolorganizationid | 100.0% | str:4745 | 49 | no | 'NULL'; '101569'; '101571' |
+| schoolyear | 100.0% | str:4745 | 8 | no | '2024-25'; '2023-24'; '2022-23' |
+| sumyearsexperience | 100.0% | str:4745 | 1684 | no | '18718.5'; '12873.5'; 'NULL' |
+| teachercount | 100.0% | str:4745 | 143 | no | '1530'; '1083'; '0' |
+| teacherpercent | 100.0% | str:4745 | 523 | no | '1.000'; '0.708'; '0.000' |
+| teachertotalcount | 100.0% | str:4745 | 81 | no | '1530'; 'NULL'; '31' |
+
+### teacher_experience.json
+
+| field | coverage | types | distinct_cap | overflow | examples |
+| --- | --- | --- | --- | --- | --- |
+| county | 100.0% | str:4602 | 1 | no | 'King' |
+| dataasof | 100.0% | str:4602 | 1 | no | '2025-12-17' |
+| esdname | 100.0% | str:4602 | 1 | no | 'Puget Sound Educational Service District 121' |
+| esdorganizationid | 100.0% | str:4602 | 1 | no | '100006' |
+| experiencebin | 100.0% | str:4602 | 13 | no | '0.0 - 4.9'; '5.0 - 9.9'; '10.0 - 14.9' |
+| iseevalidated | 100.0% | str:4602 | 1 | no | '1' |
+| leacode | 100.0% | str:4602 | 1 | no | '17415' |
+| leaname | 100.0% | str:4602 | 1 | no | 'Kent School District' |
+| leaorganizationid | 100.0% | str:4602 | 1 | no | '100117' |
+| organizationid | 100.0% | str:4602 | 48 | no | '100117'; '106971'; '101606' |
+| organizationlevel | 100.0% | str:4602 | 2 | no | 'LEA'; 'School' |
+| organizationlevelid | 100.0% | str:4602 | 2 | no | '3'; '4' |
+| organizationname | 100.0% | str:4602 | 48 | no | 'Kent School District'; 'Canyon Ridge Middle School'; 'Carriage Crest Elementary School' |
+| rowid | 100.0% | str:4602 | 4602 | no | '241307'; '241308'; '241309' |
+| schoolcode | 100.0% | str:4602 | 48 | no | 'NULL'; '5738'; '4353' |
+| schoolname | 100.0% | str:4602 | 48 | no | 'NULL'; 'Canyon Ridge Middle School'; 'Carriage Crest Elementary School' |
+| schoolorganizationid | 100.0% | str:4602 | 48 | no | 'NULL'; '106971'; '101606' |
+| schoolyear | 100.0% | str:4602 | 8 | no | '2024-25'; '2023-24'; '2022-23' |
+| teachercount | 100.0% | str:4602 | 88 | no | '395'; '358'; '234' |
+| teacherpercent | 100.0% | str:4602 | 357 | no | '25.8'; '23.4'; '15.3' |
+| teachertotalcount | 100.0% | str:4602 | 80 | no | '1530'; '46'; '24' |
+
+### wakids.json
+
+| field | coverage | types | distinct_cap | overflow | examples |
+| --- | --- | --- | --- | --- | --- |
+| county | 100.0% | str:210202 | 1 | no | 'King' |
+| dataasof | 100.0% | str:210202 | 2 | no | '2025-11-13T14:14:27.847'; '2025-12-31T16:50:58.367' |
+| districtname | 100.0% | str:210202 | 1 | no | 'Kent School District' |
+| districtorganizationid | 100.0% | str:210202 | 1 | no | '100117' |
+| domain | 100.0% | str:210202 | 7 | no | 'Cognitive'; 'Language'; 'Literacy' |
+| esdname | 100.0% | str:210202 | 1 | no | 'Puget Sound Educational Service District 121' |
+| esdorganizationid | 100.0% | str:210202 | 1 | no | '100006' |
+| measure | 100.0% | str:210202 | 17 | no | 'CognitiveDevelopmentLevel'; 'CognitiveReadinessFlag'; 'LanguageDevelopmentLevel' |
+| organizationid | 100.0% | str:210202 | 30 | no | '100117'; '101571'; '101575' |
+| organizationlevel | 100.0% | str:210202 | 2 | no | 'District'; 'School' |
+| schoolname | 100.0% | str:210202 | 30 | no | 'District Total'; 'Meridian Elementary School'; 'East Hill Elementary School' |
+| schoolyear | 100.0% | str:210202 | 12 | no | '2014-15'; '2015-16'; '2016-17' |
+| studentgroup | 100.0% | str:210202 | 21 | no | 'All Students'; 'English Language Learners'; 'Non-English Language Learners' |
+| studentgrouptype | 100.0% | str:210202 | 8 | no | 'All'; 'Bilingual'; 'FederalRaceEthnicity' |
+| washingtonstatecode | 100.0% | str:210202 | 1 | no | '103300' |
+| washingtonstatename | 100.0% | str:210202 | 1 | no | 'State Total' |
+| measurevalue | 99.48% | str:209108 | 14 | no | 'Blue'; 'Green'; 'orange' |
+| schoolorganizationid | 94.41% | str:198456 | 29 | no | '101571'; '101575'; '101580' |
+| percent | 80.94% | str:170144 | 5000 | yes | '0.48098'; '0.16195'; '0.04390' |
+| denominator | 67.94% | str:142813 | 725 | no | '1025'; '1035'; '1026' |
+| numerator | 67.94% | str:142813 | 1092 | no | '493'; '166'; '45' |
+| developmentlevel | 55.37% | str:116380 | 5 | no | '4 Year Olds'; '3 Year Olds'; '0-2 Year Olds' |
+| suppress | 32.06% | str:67389 | 2 | no | 'N<10'; 'Cross Student Group' |
+
+## Candidate Record Identity Fields
+
+| dataset | candidate fields |
+| --- | --- |
+| assessment.json | county, districtcode, districtname, districtorganizationid, esdname, esdorganizationid, gradelevel, organizationlevel, schoolname, schoolyear, studentgroup, studentgrouptype, testadministration, testsubject, schoolorganizationid, currentschooltype, schoolcode, suppression |
+| attendance.json | county, districtcode, districtname, districtorganizationid, esdname, gradelevel, organizationlevel, schoolname, schoolyear, studentgroup, studentgrouptype, currentschooltype, schoolcode, schoolorganizationid, esdorganizationid, measures, suppression, measure, organizationname |
+| discipline.json | county, districtcode, districtname, districtorganizationid, esdname, esdorganizationid, gradelevel, organizationlevel, schoolname, schoolyear, currentschooltype, schoolcode, schoolorganizationid |
+| enrollment.json | county, districtcode, districtname, districtorganizationid, esdname, esdorganizationid, gender_x, gradelevel, organizationlevel, schoolname, schoolyear, currentschooltype, schoolcode, schoolorganizationid |
+| graduation.json | cohort, county, districtcode, districtname, districtorganizationid, esdname, esdorganizationid, organizationlevel, schoolname, schoolyear, studentgroup, studentgrouptype, schoolcode, schoolorganizationid, suppression |
+| growth.json | county, districtcode, districtname, districtorganizationid, esdname, esdorganizationid, gradelevel, organizationlevel, schoolname, schoolyear, studentgroup, studentgrouptype, subject, schoolcode, schoolorganizationid, currentschooltype, suppression |
+| sqss.json | county, districtcode, districtname, districtorganizationid, esdname, gradelevel, organizationlevel, schoolname, schoolyear, studentgroup, studentgrouptype, currentschooltype, schoolcode, schoolorganizationid, esdorganizationid, measures, suppression, measure, organizationname |
+| teacher_demographics.json | county, demographiccategory, demographiccategoryid, demographiccategorytype, esdname, esdorganizationid, iseevalidated, leacode, leaname, leaorganizationid, organizationid, organizationlevel, organizationlevelid, organizationname, rowid, schoolcode, schoolname, schoolorganizationid, schoolyear |
+| teacher_experience.json | county, esdname, esdorganizationid, experiencebin, iseevalidated, leacode, leaname, leaorganizationid, organizationid, organizationlevel, organizationlevelid, organizationname, rowid, schoolcode, schoolname, schoolorganizationid, schoolyear |
+| wakids.json | county, districtname, districtorganizationid, domain, esdname, esdorganizationid, measure, organizationid, organizationlevel, schoolname, schoolyear, studentgroup, studentgrouptype, washingtonstatecode, washingtonstatename, schoolorganizationid |
+
+## Year Ranges
+
+| dataset | field | min | max | sample values | coverage_pct |
+| --- | --- | --- | --- | --- | --- |
+| assessment.json | schoolyear | 2014 | 2024 | 2014, 2015, 2016, 2017, 2018, 2020, 2021, 2022, 2023, 2024 | 100.0 |
+| attendance.json | schoolyear | 2014 | 2023 | 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 | 100.0 |
+| discipline.json | schoolyear | 2014 | 2023 | 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 | 100.0 |
+| enrollment.json | schoolyear | 2014 | 2025 | 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 | 100.0 |
+| graduation.json | schoolyear | 2014 | 2024 | 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024 | 100.0 |
+| growth.json | schoolyear | 2014 | 2024 | 2014, 2015, 2016, 2017, 2018, 2022, 2023, 2024 | 100.0 |
+| sqss.json | schoolyear | 2014 | 2023 | 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023 | 100.0 |
+| teacher_demographics.json | schoolyear | 2017 | 2024 | 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024 | 100.0 |
+| teacher_experience.json | schoolyear | 2017 | 2024 | 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024 | 100.0 |
+| wakids.json | schoolyear | 2014 | 2025 | 2014, 2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022, 2023, 2024, 2025 | 100.0 |
+
+## Kent School District Signals
+
+| dataset | matching records | signals | examples |
+| --- | --- | --- | --- |
+| assessment.json | 155528 | districtcode=17415:155528, districtname=Kent School District:155528, districtorganizationid=100117:155528 | ['districtcode=17415', 'districtname=Kent School District', 'districtorganizationid=100117'] |
+| attendance.json | 75204 | districtcode=17415:75204, districtname=Kent School District:75204, districtorganizationid=100117:75204, organizationname=Kent School District:422 | ['districtcode=17415', 'districtname=Kent School District', 'districtorganizationid=100117']; ['organizationname=Kent School District', 'districtcode=17415', 'districtname=Kent School District', 'districtorganiz... |
+| discipline.json | 74033 | districtcode=17415:74033, districtname=Kent School District:74033, districtorganizationid=100117:74033 | ['districtcode=17415', 'districtname=Kent School District', 'districtorganizationid=100117'] |
+| enrollment.json | 4562 | districtcode=17415:4562, districtname=Kent School District:4562, districtorganizationid=100117:4562 | ['districtcode=17415', 'districtname=Kent School District', 'districtorganizationid=100117'] |
+| graduation.json | 9670 | districtcode=17415:9670, districtname=Kent School District:9670, districtorganizationid=100117:9670 | ['districtcode=17415', 'districtname=Kent School District', 'districtorganizationid=100117'] |
+| growth.json | 50665 | districtcode=17415:50665, districtname=Kent School District:50665, districtorganizationid=100117:50665 | ['districtcode=17415', 'districtname=Kent School District', 'districtorganizationid=100117'] |
+| sqss.json | 109011 | districtcode=17415:109011, districtname=Kent School District:109011, districtorganizationid=100117:109011, organizationname=Kent School District:635 | ['districtcode=17415', 'districtname=Kent School District', 'districtorganizationid=100117']; ['organizationname=Kent School District', 'districtcode=17415', 'districtname=Kent School District', 'districtorganiz... |
+| teacher_demographics.json | 4745 | leaname=Kent School District:4745, organizationid=100117:104, organizationname=Kent School District:104 | ['organizationid=100117', 'organizationname=Kent School District', 'leaname=Kent School District']; ['leaname=Kent School District'] |
+| teacher_experience.json | 4602 | leaname=Kent School District:4602, organizationid=100117:104, organizationname=Kent School District:104 | ['organizationid=100117', 'organizationname=Kent School District', 'leaname=Kent School District']; ['leaname=Kent School District'] |
+| wakids.json | 210202 | districtname=Kent School District:210202, districtorganizationid=100117:210202, organizationid=100117:11746 | ['organizationid=100117', 'districtorganizationid=100117', 'districtname=Kent School District']; ['districtorganizationid=100117', 'districtname=Kent School District'] |
+
+## Null, Missing, And Suppression Patterns
+
+| dataset | field | null_like | blank | suppressed | suppression examples |
+| --- | --- | --- | --- | --- | --- |
+| assessment.json | studentgroup | 1528 | 0 | 0 |  |
+| assessment.json | schoolorganizationid | 936 | 0 | 0 |  |
+| assessment.json | percentmetstandard | 0 | 0 | 49783 | '<10%'; 'Suppressed: N<10' |
+| assessment.json | suppression | 46659 | 0 | 62525 | '<10%'; 'N<10'; 'Cross Student Group - N<10' |
+| assessment.json | percentlevel1 | 6058 | 0 | 0 |  |
+| assessment.json | percentlevel2 | 6058 | 0 | 0 |  |
+| assessment.json | percentlevel3 | 6058 | 0 | 0 |  |
+| assessment.json | percentlevel4 | 6058 | 0 | 0 |  |
+| assessment.json | count_of_students_expected | 8459 | 0 | 0 |  |
+| assessment.json | count_of_students_expected_to_test_including_previously_passed | 8220 | 0 | 0 |  |
+| assessment.json | dat | 15931 | 0 | 20745 | 'N<10'; 'Cross Student Group - N<10'; '<10%' |
+| assessment.json | percent_consistent_grade_level_knowledge_and_above | 0 | 0 | 10381 | 'N<10'; '<10%'; '<10.0%' |
+| assessment.json | percent_foundational_grade | 0 | 0 | 10844 | 'N<10'; '<10%' |
+| assessment.json | count_consistent_grade_level_knowledge_and_above | 8459 | 0 | 0 |  |
+| assessment.json | percent_consistent_grade | 0 | 0 | 5714 | 'N<10'; '<10%' |
+| assessment.json | percent_consistent_tested_only | 6058 | 0 | 0 |  |
+| assessment.json | percentnoscore | 6058 | 0 | 0 |  |
+| assessment.json | percentparticipation | 6058 | 0 | 0 |  |
+| attendance.json | suppression | 0 | 0 | 43995 | 'Suppressed: N<10'; 'No Suppression'; 'Suppressed: >95%' |
+| attendance.json | suppressionreason | 0 | 0 | 14951 | 'No Suppression'; 'Suppressed: >92%'; 'Suppressed: >94%' |
+| attendance.json | datreason | 4069 | 0 | 3208 | 'N<10'; 'Cross Student Group - N<10'; 'Cross Organization - N<10' |
+| attendance.json | dat_reason | 4296 | 0 | 2831 | 'Cross Student Group - N<10'; 'Cross Grade Level - N<10'; 'N<10' |
+| attendance.json | label | 0 | 0 | 1757 | 'N<10' |
+| discipline.json | disciplinedatnotes | 9466 | 0 | 20231 | 'N<10'; 'Cross Student Group - N<10'; 'Cross Grade Level - N<10' |
+| discipline.json | disciplinedenominator | 0 | 0 | 64567 | '*' |
+| discipline.json | disciplinenumerator | 0 | 0 | 64567 | '*' |
+| discipline.json | disciplinerate | 0 | 0 | 18738 | 'N<10'; '<10.0%'; '<10.7%' |
+| discipline.json | rateexcluded10daysormore | 0 | 0 | 20231 | 'N<10'; 'Cross Student Group - N<10'; 'Cross Grade Level - N<10' |
+| discipline.json | rateexcluded1dayorless | 0 | 0 | 20231 | 'N<10'; 'Cross Student Group - N<10'; 'Cross Grade Level - N<10' |
+| discipline.json | rateexcluded2to3days | 0 | 0 | 20231 | 'N<10'; 'Cross Student Group - N<10'; 'Cross Grade Level - N<10' |
+| discipline.json | rateexcluded4to5days | 0 | 0 | 20231 | 'N<10'; 'Cross Student Group - N<10'; 'Cross Grade Level - N<10' |
+| discipline.json | rateexcluded6to10days | 0 | 0 | 20231 | 'N<10'; 'Cross Student Group - N<10'; 'Cross Grade Level - N<10' |
+| discipline.json | excluded10daysormore | 0 | 0 | 58766 | '*' |
+| discipline.json | excluded1dayorless | 0 | 0 | 58766 | '*' |
+| discipline.json | excluded2to3days | 0 | 0 | 58766 | '*' |
+| discipline.json | excluded4to5days | 0 | 0 | 58766 | '*' |
+| discipline.json | excluded6to10days | 0 | 0 | 58766 | '*' |
+| graduation.json | schoolcode | 980 | 0 | 0 |  |
+| graduation.json | schoolorganizationid | 980 | 0 | 0 |  |
+| graduation.json | graduationrate | 3619 | 0 | 0 |  |
+| graduation.json | graduate | 6101 | 0 | 0 |  |
+| graduation.json | transferout | 6101 | 0 | 0 |  |
+| graduation.json | year4dropout | 6178 | 0 | 0 |  |
+| graduation.json | year3dropout | 6415 | 0 | 0 |  |
+| graduation.json | year1dropout | 7261 | 0 | 0 |  |
+| graduation.json | year2dropout | 6814 | 0 | 0 |  |
+| graduation.json | year5dropout | 7122 | 0 | 0 |  |
+| graduation.json | year6dropout | 8047 | 0 | 0 |  |
+| graduation.json | year7dropout | 8493 | 0 | 0 |  |
+| graduation.json | finalcohort | 5473 | 0 | 0 |  |
+| graduation.json | transferin | 5490 | 0 | 0 |  |
+| graduation.json | beggininggrade9 | 5222 | 0 | 0 |  |
+| graduation.json | suppression | 0 | 0 | 2055 | '<10.7%'; 'N<10'; '<10.0%' |
+| graduation.json | continuing | 2134 | 0 | 0 |  |
+| graduation.json | dropout | 2134 | 0 | 0 |  |
+| graduation.json | dat | 0 | 0 | 856 | 'N<10'; '<10.3%'; '<10.0%' |
+| graduation.json | beginninggrade9 | 879 | 0 | 0 |  |
+| graduation.json | final_cohort | 628 | 0 | 0 |  |
+| graduation.json | transferredin | 631 | 0 | 0 |  |
+| growth.json | schoolcode | 1072 | 0 | 0 |  |
+| growth.json | schoolorganizationid | 1072 | 0 | 0 |  |
+| growth.json | mediansgp | 7792 | 0 | 0 |  |
+| growth.json | percenthighgrowth | 8610 | 0 | 0 |  |
+| growth.json | percentlowgrowth | 8610 | 0 | 0 |  |
+| growth.json | percenttypicalgrowth | 8610 | 0 | 0 |  |
+| growth.json | numberhighgrowth | 11049 | 0 | 0 |  |
+| growth.json | numberlowgrowth | 11049 | 0 | 0 |  |
+| growth.json | numbertypicalgrowth | 11049 | 0 | 0 |  |
+| growth.json | studentcount | 11045 | 0 | 0 |  |
+| growth.json | suppression | 4237 | 0 | 14885 | 'Suppressed: N<10'; 'Suppressed: Cross Group'; 'Suppressed: Cross Grade' |
+| growth.json | datreason | 7942 | 0 | 3647 | 'N<10' |
+| sqss.json | suppression | 0 | 0 | 64105 | 'Suppressed: N<10'; 'No Suppression'; 'Suppressed: >95%' |
+| sqss.json | suppressionreason | 0 | 0 | 21545 | 'No Suppression'; 'Suppressed: >92%'; 'Suppressed: >94%' |
+| sqss.json | dat_reason | 5167 | 0 | 3365 | 'Cross Student Group - N<10'; 'Cross Grade Level - N<10'; 'N<10' |
+| sqss.json | label | 0 | 0 | 2107 | 'N<10'; '<10.0%'; '<10.3%' |
+| sqss.json | datreason | 6772 | 0 | 3797 | 'N<10'; 'Cross Student Group - N<10'; 'Cross Organization - N<10' |
+| teacher_demographics.json | avgyearsexperience | 2265 | 0 | 0 |  |
+| teacher_demographics.json | ma_count | 143 | 0 | 0 |  |
+| teacher_demographics.json | ma_percent | 1882 | 0 | 0 |  |
+| teacher_demographics.json | schoolcode | 104 | 0 | 0 |  |
+| teacher_demographics.json | schoolname | 104 | 0 | 0 |  |
+| teacher_demographics.json | schoolorganizationid | 104 | 0 | 0 |  |
+| teacher_demographics.json | sumyearsexperience | 2265 | 0 | 0 |  |
+| teacher_demographics.json | teachercount | 143 | 0 | 0 |  |
+| teacher_demographics.json | teacherpercent | 143 | 0 | 0 |  |
+| teacher_demographics.json | teachertotalcount | 143 | 0 | 0 |  |
+| teacher_experience.json | schoolcode | 104 | 0 | 0 |  |
+| teacher_experience.json | schoolname | 104 | 0 | 0 |  |
+| teacher_experience.json | schoolorganizationid | 104 | 0 | 0 |  |
+| wakids.json | suppress | 0 | 0 | 40058 | 'N<10' |
+
+## Numeric Field Patterns
+
+| dataset | field | numeric | numeric strings | percent strings | min | max | types |
+| --- | --- | --- | --- | --- | --- | --- | --- |
+| assessment.json | county | 0 | 0 | 0 | None | None | str:155528 |
+| assessment.json | districtcode | 0 | 155528 | 0 | 17415.0 | 17415.0 | str:155528 |
+| assessment.json | districtorganizationid | 0 | 155528 | 0 | 100117.0 | 100117.0 | str:155528 |
+| assessment.json | esdorganizationid | 0 | 155528 | 0 | 100006.0 | 100006.0 | str:155528 |
+| assessment.json | gradelevel | 0 | 109489 | 0 | 1.0 | 12.0 | str:155528 |
+| assessment.json | organizationlevel | 0 | 0 | 0 | None | None | str:155528 |
+| assessment.json | schoolorganizationid | 0 | 144551 | 0 | 101569.0 | 106971.0 | str:145487 |
+| assessment.json | schoolcode | 0 | 144551 | 0 | 1807.0 | 5738.0 | str:144551 |
+| assessment.json | percentmetstandard | 0 | 61542 | 61542 | 1.1 | 95.1 | str:114615 |
+| assessment.json | percentlevel1 | 0 | 83418 | 0 | 0.0 | 0.9247311827956 | str:89476 |
+| assessment.json | percentlevel2 | 0 | 83418 | 0 | 0.0 | 0.9285714285714 | str:89476 |
+| assessment.json | percentlevel3 | 0 | 83418 | 0 | 0.0 | 0.8 | str:89476 |
+| assessment.json | percentlevel4 | 0 | 83418 | 0 | 0.0 | 0.8260869565217 | str:89476 |
+| assessment.json | percent_no_score | 0 | 75836 | 0 | 0.0 | 0.9698275862068 | str:75836 |
+| assessment.json | count_of_students_expected | 0 | 62490 | 0 | 10.0 | 14302.0 | str:70949 |
+| assessment.json | percentmettestedonly | 0 | 61542 | 0 | 0.0144404332129 | 1.0 | str:61542 |
+| assessment.json | count_of_students_expected_to_test_including_previously_passed | 0 | 52079 | 0 | 10.0 | 14302.0 | str:60299 |
+| assessment.json | countmetstandard | 0 | 46659 | 0 | 2.0 | 8285.0 | str:46659 |
+| assessment.json | percent_consistent_grade_level_knowledge_and_above | 0 | 15024 | 15024 | 1.15 | 91.7 | str:27166 |
+| assessment.json | percent_foundational_grade | 0 | 15654 | 15654 | 3.6 | 100.0 | str:26964 |
+| assessment.json | count_consistent_grade_level_knowledge_and_above | 0 | 10678 | 0 | 3.0 | 6139.0 | str:19137 |
+| assessment.json | percent_consistent_grade | 0 | 7318 | 7318 | 1.8 | 89.7 | str:13747 |
+| assessment.json | percent_consistent_tested_only | 0 | 7582 | 0 | 0.02849002849 | 0.9111111111111 | str:13640 |
+| assessment.json | percentnoscore | 0 | 7582 | 0 | 0.0 | 0.696 | str:13640 |
+| assessment.json | percentparticipation | 0 | 7582 | 0 | 0.304 | 1.0 | str:13640 |
+| assessment.json | percent_participation | 0 | 13509 | 0 | 0.35106383 | 1.0 | str:13509 |
+| assessment.json | count_foundational_grade | 0 | 11303 | 0 | 3.0 | 8408.0 | str:11303 |
+| assessment.json | count_of_students_expected_1 | 0 | 10341 | 0 | 10.0 | 13075.0 | str:10341 |
+| assessment.json | percent_taking_alternative_assessment | 0 | 8055 | 0 | 0.0 | 1.0 | str:8055 |
+| assessment.json | percent_taking_alternative | 0 | 7966 | 0 | 0.0 | 1.0 | str:7966 |
+| assessment.json | percent_met_tested_only | 0 | 7170 | 0 | 0.016949153 | 0.929577465 | str:7170 |
+| assessment.json | percent_consistent_tested | 0 | 7124 | 0 | 0.0193370165745 | 0.9285714285714 | str:7124 |
+| assessment.json | count_consistent_grade_level | 0 | 5153 | 0 | 4.0 | 5545.0 | str:5153 |
+| attendance.json | county | 0 | 0 | 0 | None | None | str:75204 |
+| attendance.json | districtcode | 0 | 75204 | 0 | 17415.0 | 17415.0 | str:75204 |
+| attendance.json | districtorganizationid | 0 | 75204 | 0 | 100117.0 | 100117.0 | str:75204 |
+| attendance.json | gradelevel | 0 | 56001 | 0 | 1.0 | 12.0 | str:75204 |
+| attendance.json | organizationlevel | 0 | 0 | 0 | None | None | str:75204 |
+| attendance.json | schoolcode | 0 | 71147 | 0 | 1807.0 | 5738.0 | str:71147 |
+| attendance.json | schoolorganizationid | 0 | 71147 | 0 | 101569.0 | 106971.0 | str:71147 |
+| attendance.json | esdorganizationid | 0 | 67551 | 0 | 100006.0 | 100006.0 | str:67551 |
+| attendance.json | denominator | 0 | 35300 | 0 | 0.0 | 28244.0 | str:35300 |
+| attendance.json | numerator | 0 | 34354 | 0 | 2.0 | 24454.0 | str:34354 |
+| attendance.json | label | 0 | 5370 | 5370 | 11.8 | 94.6 | str:7653 |
+| attendance.json | percent | 0 | 5821 | 0 | 0.1176 | 0.9948 | str:5821 |
+| discipline.json | county | 0 | 0 | 0 | None | None | str:74033 |
+| discipline.json | disciplinedatnotes | 0 | 0 | 0 | None | None | str:74033 |
+| discipline.json | disciplinedenominator | 0 | 9466 | 0 | 10.0 | 30001.0 | str:74033 |
+| discipline.json | disciplinenumerator | 0 | 9466 | 0 | 3.0 | 1250.0 | str:74033 |
+| discipline.json | disciplinerate | 0 | 15280 | 15280 | 0.02 | 63.64 | str:74033 |
+| discipline.json | districtcode | 0 | 74033 | 0 | 17415.0 | 17415.0 | str:74033 |
+| discipline.json | districtorganizationid | 0 | 74033 | 0 | 100117.0 | 100117.0 | str:74033 |
+| discipline.json | esdorganizationid | 0 | 74033 | 0 | 100006.0 | 100006.0 | str:74033 |
+| discipline.json | gradelevel | 0 | 0 | 0 | None | None | str:74033 |
+| discipline.json | organizationlevel | 0 | 0 | 0 | None | None | str:74033 |
+| discipline.json | rateexcluded10daysormore | 0 | 12388 | 12388 | 0.0 | 100.0 | str:74033 |
+| discipline.json | rateexcluded1dayorless | 0 | 12388 | 12388 | 0.0 | 100.0 | str:74033 |
+| discipline.json | rateexcluded2to3days | 0 | 12388 | 12388 | 0.0 | 100.0 | str:74033 |
+| discipline.json | rateexcluded4to5days | 0 | 12388 | 12388 | 0.0 | 100.0 | str:74033 |
+| discipline.json | rateexcluded6to10days | 0 | 12388 | 12388 | 0.0 | 100.0 | str:74033 |
+| discipline.json | schoolcode | 0 | 70140 | 0 | 1807.0 | 5738.0 | str:70140 |
+| discipline.json | schoolorganizationid | 0 | 70140 | 0 | 101569.0 | 106971.0 | str:70140 |
+| discipline.json | excluded10daysormore | 0 | 9466 | 0 | 0.0 | 152.0 | str:68232 |
+| discipline.json | excluded1dayorless | 0 | 9466 | 0 | 0.0 | 320.0 | str:68232 |
+| discipline.json | excluded2to3days | 0 | 9466 | 0 | 0.0 | 430.0 | str:68232 |
+| discipline.json | excluded4to5days | 0 | 9466 | 0 | 0.0 | 218.0 | str:68232 |
+| discipline.json | excluded6to10days | 0 | 9466 | 0 | 0.0 | 182.0 | str:68232 |
+| enrollment.json | all_students | 0 | 4562 | 0 | 0.0 | 28151.0 | str:4562 |
+| enrollment.json | american_indian_alaskan_native | 0 | 4562 | 0 | 0.0 | 127.0 | str:4562 |
+| enrollment.json | asian | 0 | 4562 | 0 | 0.0 | 6217.0 | str:4562 |
+| enrollment.json | black_african_american | 0 | 4562 | 0 | 0.0 | 3468.0 | str:4562 |
+| enrollment.json | county | 0 | 0 | 0 | None | None | str:4562 |
+| enrollment.json | districtcode | 0 | 4562 | 0 | 17415.0 | 17415.0 | str:4562 |
+| enrollment.json | districtorganizationid | 0 | 4562 | 0 | 100117.0 | 100117.0 | str:4562 |
+| enrollment.json | english_language_learners | 0 | 4562 | 0 | 0.0 | 8076.0 | str:4562 |
+| enrollment.json | esdorganizationid | 0 | 4562 | 0 | 100006.0 | 100006.0 | str:4562 |
+| enrollment.json | female | 0 | 4562 | 0 | 0.0 | 13564.0 | str:4562 |
+| enrollment.json | gender_x | 0 | 4562 | 0 | 0.0 | 48.0 | str:4562 |
+| enrollment.json | gradelevel | 0 | 0 | 0 | None | None | str:4562 |
+| enrollment.json | highly_capable | 0 | 4562 | 0 | 0.0 | 3107.0 | str:4562 |
+| enrollment.json | hispanic_latino_of_any_race | 0 | 4562 | 0 | 0.0 | 6364.0 | str:4562 |
+| enrollment.json | homeless | 0 | 4562 | 0 | 0.0 | 631.0 | str:4562 |
+| enrollment.json | low_income | 0 | 4562 | 0 | 0.0 | 15842.0 | str:4562 |
+| enrollment.json | male | 0 | 4562 | 0 | 0.0 | 14720.0 | str:4562 |
+| enrollment.json | migrant | 0 | 4562 | 0 | 0.0 | 56.0 | str:4562 |
+| enrollment.json | military_parent | 0 | 4562 | 0 | 0.0 | 346.0 | str:4562 |
+| enrollment.json | mobile | 0 | 4562 | 0 | 0.0 | 1188.0 | str:4562 |
+| enrollment.json | non_english_language_learners | 0 | 4562 | 0 | 0.0 | 23075.0 | str:4562 |
+| enrollment.json | non_highly_capable | 0 | 4562 | 0 | 0.0 | 27776.0 | str:4562 |
+| enrollment.json | non_homeless | 0 | 4562 | 0 | 0.0 | 27759.0 | str:4562 |
+| enrollment.json | non_low_income | 0 | 4562 | 0 | 0.0 | 13973.0 | str:4562 |
+| enrollment.json | non_migrant | 0 | 4562 | 0 | 0.0 | 28095.0 | str:4562 |
+| enrollment.json | non_military_parent | 0 | 4562 | 0 | 0.0 | 28151.0 | str:4562 |
+| enrollment.json | non_mobile | 0 | 4562 | 0 | 0.0 | 27084.0 | str:4562 |
+| enrollment.json | non_section_504 | 0 | 4562 | 0 | 0.0 | 26911.0 | str:4562 |
+| enrollment.json | organizationlevel | 0 | 0 | 0 | None | None | str:4562 |
+| enrollment.json | section_504 | 0 | 4562 | 0 | 0.0 | 1469.0 | str:4562 |
+| enrollment.json | students_with_disabilities | 0 | 4562 | 0 | 0.0 | 3851.0 | str:4562 |
+| enrollment.json | students_without_disabilities | 0 | 4562 | 0 | 0.0 | 25124.0 | str:4562 |
+| enrollment.json | two_or_more_races | 0 | 4562 | 0 | 0.0 | 2719.0 | str:4562 |
+| enrollment.json | white | 0 | 4562 | 0 | 0.0 | 10329.0 | str:4562 |
+| enrollment.json | schoolcode | 0 | 4346 | 0 | 1807.0 | 5738.0 | str:4346 |
+| graduation.json | county | 0 | 0 | 0 | None | None | str:9670 |
+| graduation.json | districtcode | 0 | 9670 | 0 | 17415.0 | 17415.0 | str:9670 |
+| graduation.json | districtorganizationid | 0 | 9670 | 0 | 100117.0 | 100117.0 | str:9670 |
+| graduation.json | esdorganizationid | 0 | 9670 | 0 | 100006.0 | 100006.0 | str:9670 |
+| graduation.json | organizationlevel | 0 | 0 | 0 | None | None | str:9670 |
+| graduation.json | studentgrouptype | 0 | 801 | 0 | 504.0 | 504.0 | str:9670 |
+| graduation.json | schoolcode | 0 | 8574 | 0 | 1807.0 | 5729.0 | str:9554 |
+| graduation.json | schoolorganizationid | 0 | 8574 | 0 | 101569.0 | 106918.0 | str:9554 |
+| graduation.json | graduationrate | 0 | 5585 | 0 | 0.010909090909 | 0.9894736842105 | str:9204 |
+| graduation.json | graduate | 0 | 2737 | 0 | 3.0 | 1713.0 | str:8838 |
+| graduation.json | transferout | 0 | 2737 | 0 | 0.0 | 349.0 | str:8838 |
+| graduation.json | year4dropout | 0 | 2654 | 0 | 1.0 | 159.0 | str:8832 |
+| graduation.json | year3dropout | 0 | 2414 | 0 | 1.0 | 67.0 | str:8829 |
+| graduation.json | year1dropout | 0 | 1541 | 0 | 1.0 | 90.0 | str:8802 |
+| graduation.json | year2dropout | 0 | 1984 | 0 | 1.0 | 35.0 | str:8798 |
+| graduation.json | year5dropout | 0 | 1659 | 0 | 1.0 | 157.0 | str:8781 |
+| graduation.json | year6dropout | 0 | 711 | 0 | 1.0 | 128.0 | str:8758 |
+| graduation.json | year7dropout | 0 | 248 | 0 | 1.0 | 81.0 | str:8741 |
+| graduation.json | finalcohort | 0 | 2472 | 0 | 10.0 | 1936.0 | str:7945 |
+| graduation.json | transferin | 0 | 2455 | 0 | 1.0 | 351.0 | str:7945 |
+| graduation.json | beggininggrade9 | 0 | 2504 | 0 | 9.0 | 1878.0 | str:7726 |
+| graduation.json | continuing | 0 | 761 | 0 | 0.0 | 106.0 | str:2895 |
+| graduation.json | dropout | 0 | 761 | 0 | 0.0 | 218.0 | str:2895 |
+| graduation.json | beginninggrade9 | 0 | 233 | 0 | 24.0 | 1763.0 | str:1112 |
+| graduation.json | final_cohort | 0 | 265 | 0 | 12.0 | 1881.0 | str:893 |
+| graduation.json | transferredin | 0 | 262 | 0 | 1.0 | 258.0 | str:893 |
+| growth.json | county | 0 | 0 | 0 | None | None | str:50665 |
+| growth.json | districtcode | 0 | 50665 | 0 | 17415.0 | 17415.0 | str:50665 |
+| growth.json | districtorganizationid | 0 | 50665 | 0 | 100117.0 | 100117.0 | str:50665 |
+| growth.json | esdorganizationid | 0 | 50665 | 0 | 100006.0 | 100006.0 | str:50665 |
+| growth.json | gradelevel | 0 | 8852 | 0 | 4.0 | 8.0 | str:50665 |
+| growth.json | organizationlevel | 0 | 0 | 0 | None | None | str:50665 |
+| growth.json | schoolcode | 0 | 48193 | 0 | 2565.0 | 5738.0 | str:49265 |
+| growth.json | schoolorganizationid | 0 | 48193 | 0 | 101571.0 | 106971.0 | str:49265 |
+| growth.json | mediansgp | 0 | 34072 | 0 | 3.0 | 97.0 | str:41864 |
+| growth.json | percenthighgrowth | 0 | 33254 | 0 | 0.0 | 2532.0 | str:41864 |
+| growth.json | percentlowgrowth | 0 | 33254 | 0 | 0.0 | 3030.0 | str:41864 |
+| growth.json | percenttypicalgrowth | 0 | 33254 | 0 | 0.0 | 2760.0 | str:41864 |
+| growth.json | numberhighgrowth | 0 | 26986 | 0 | 0.0 | 3312.0 | str:38035 |
+| growth.json | numberlowgrowth | 0 | 26986 | 0 | 0.0 | 3535.0 | str:38035 |
+| growth.json | numbertypicalgrowth | 0 | 26986 | 0 | 0.0 | 3298.0 | str:38035 |
+| growth.json | studentcount | 0 | 26990 | 0 | 10.0 | 9594.0 | str:38035 |
+| sqss.json | county | 0 | 0 | 0 | None | None | str:109011 |
+| sqss.json | districtcode | 0 | 109011 | 0 | 17415.0 | 17415.0 | str:109011 |
+| sqss.json | districtorganizationid | 0 | 109011 | 0 | 100117.0 | 100117.0 | str:109011 |
+| sqss.json | gradelevel | 0 | 66504 | 0 | 1.0 | 12.0 | str:109011 |
+| sqss.json | organizationlevel | 0 | 0 | 0 | None | None | str:109011 |
+| sqss.json | schoolcode | 0 | 102985 | 0 | 1807.0 | 5738.0 | str:102985 |
+| sqss.json | schoolorganizationid | 0 | 102985 | 0 | 101569.0 | 106971.0 | str:102985 |
+| sqss.json | esdorganizationid | 0 | 97719 | 0 | 100006.0 | 100006.0 | str:97719 |
+| sqss.json | denominator | 0 | 44695 | 0 | 0.0 | 28244.0 | str:44695 |
+| sqss.json | numerator | 0 | 43749 | 0 | 0.0 | 24454.0 | str:43749 |
+| sqss.json | label | 0 | 6416 | 6416 | 0.7 | 98.4 | str:11283 |
+| sqss.json | percent | 0 | 7026 | 0 | 0.0069 | 0.9948 | str:7026 |
+| sqss.json | percenttakingctetechprep | 0 | 6922 | 0 | 0.01 | 0.9 | str:6922 |
+| sqss.json | percenttakingcollegeinth | 0 | 6823 | 0 | 0.00990099 | 0.9 | str:6823 |
+| sqss.json | percenttakingap | 0 | 6791 | 0 | 0.01 | 0.9 | str:6791 |
+| sqss.json | percenttakingrunningstart | 0 | 6660 | 0 | 0.006688963 | 0.7777777777777 | str:6660 |
+| sqss.json | percenttakingib | 0 | 6504 | 0 | 0.004459309 | 0.7857142857142 | str:6504 |
+| sqss.json | percenttakingcambridge | 0 | 6397 | 0 | 0.01 | 0.1 | str:6397 |
+| sqss.json | numbertakingctetechprep | 0 | 4722 | 0 | 2.0 | 4351.0 | str:4722 |
+| sqss.json | numbertakingap | 0 | 3572 | 0 | 1.0 | 2133.0 | str:3572 |
+| sqss.json | numbertakingcollegeinthe | 0 | 3537 | 0 | 1.0 | 1867.0 | str:3537 |
+| sqss.json | numbertakingrunningstart | 0 | 2723 | 0 | 1.0 | 1209.0 | str:2723 |
+| sqss.json | apcoursenumber | 0 | 1648 | 0 | 0.0 | 971.0 | str:1648 |
+| sqss.json | cambridgecoursenumber | 0 | 1648 | 0 | 0.0 | 0.0 | str:1648 |
+| sqss.json | cihscoursenumber | 0 | 1648 | 0 | 0.0 | 2034.0 | str:1648 |
+| sqss.json | ctecoursenumber | 0 | 1648 | 0 | 0.0 | 4105.0 | str:1648 |
+| sqss.json | ibcoursenumber | 0 | 1648 | 0 | 0.0 | 234.0 | str:1648 |
+| sqss.json | runningstartcoursenumber | 0 | 1648 | 0 | 0.0 | 1139.0 | str:1648 |
+| sqss.json | numbertakingib | 0 | 1148 | 0 | 1.0 | 428.0 | str:1148 |
+| sqss.json | apcoursepercent | 0 | 899 | 0 | 0.002 | 0.893 | str:899 |
+| sqss.json | cambridgecoursepercent | 0 | 899 | 0 | 0.0 | 0.3 | str:899 |
+| sqss.json | cihscoursepercent | 0 | 899 | 0 | 0.005 | 0.897 | str:899 |
+| sqss.json | ctecoursepercent | 0 | 899 | 0 | 0.007 | 0.885 | str:899 |
+| sqss.json | ibcoursepercent | 0 | 899 | 0 | 0.001 | 0.524 | str:899 |
+| sqss.json | runningstartcoursepercent | 0 | 899 | 0 | 0.001 | 0.735 | str:899 |
+| teacher_demographics.json | avgyearsexperience | 0 | 2480 | 0 | 0.0 | 43.9 | str:4745 |
+| teacher_demographics.json | county | 0 | 0 | 0 | None | None | str:4745 |
+| teacher_demographics.json | demographiccategoryid | 0 | 4745 | 0 | 0.0 | 12.0 | str:4745 |
+| teacher_demographics.json | esdorganizationid | 0 | 4745 | 0 | 100006.0 | 100006.0 | str:4745 |
+| teacher_demographics.json | iseevalidated | 0 | 4745 | 0 | 0.0 | 1.0 | str:4745 |
+| teacher_demographics.json | leacode | 0 | 4745 | 0 | 17415.0 | 17415.0 | str:4745 |
+| teacher_demographics.json | leaorganizationid | 0 | 4745 | 0 | 100117.0 | 100117.0 | str:4745 |
+| teacher_demographics.json | ma_count | 0 | 4602 | 0 | 0.0 | 1176.0 | str:4745 |
+| teacher_demographics.json | ma_percent | 0 | 2863 | 0 | 0.0 | 1.0 | str:4745 |
+| teacher_demographics.json | organizationid | 0 | 4745 | 0 | 100117.0 | 106971.0 | str:4745 |
+| teacher_demographics.json | organizationlevel | 0 | 0 | 0 | None | None | str:4745 |
+| teacher_demographics.json | organizationlevelid | 0 | 4745 | 0 | 3.0 | 4.0 | str:4745 |
+| teacher_demographics.json | rowid | 0 | 4745 | 0 | 1665.0 | 296556.0 | str:4745 |
+| teacher_demographics.json | schoolcode | 0 | 4641 | 0 | 1807.0 | 5738.0 | str:4745 |
+| teacher_demographics.json | schoolorganizationid | 0 | 4641 | 0 | 101569.0 | 106971.0 | str:4745 |
+| teacher_demographics.json | sumyearsexperience | 0 | 2480 | 0 | 0.0 | 18718.5 | str:4745 |
+| teacher_demographics.json | teachercount | 0 | 4602 | 0 | 0.0 | 1654.0 | str:4745 |
+| teacher_demographics.json | teacherpercent | 0 | 4602 | 0 | 0.0 | 1.0 | str:4745 |
+| teacher_demographics.json | teachertotalcount | 0 | 4602 | 0 | 1.0 | 1654.0 | str:4745 |
+| teacher_experience.json | county | 0 | 0 | 0 | None | None | str:4602 |
+| teacher_experience.json | esdorganizationid | 0 | 4602 | 0 | 100006.0 | 100006.0 | str:4602 |
+| teacher_experience.json | iseevalidated | 0 | 4602 | 0 | 1.0 | 1.0 | str:4602 |
+| teacher_experience.json | leacode | 0 | 4602 | 0 | 17415.0 | 17415.0 | str:4602 |
+| teacher_experience.json | leaorganizationid | 0 | 4602 | 0 | 100117.0 | 100117.0 | str:4602 |
+| teacher_experience.json | organizationid | 0 | 4602 | 0 | 100117.0 | 106971.0 | str:4602 |
+| teacher_experience.json | organizationlevel | 0 | 0 | 0 | None | None | str:4602 |
+| teacher_experience.json | organizationlevelid | 0 | 4602 | 0 | 3.0 | 4.0 | str:4602 |
+| teacher_experience.json | rowid | 0 | 4602 | 0 | 1652.0 | 255710.0 | str:4602 |
+| teacher_experience.json | schoolcode | 0 | 4498 | 0 | 1807.0 | 5738.0 | str:4602 |
+| teacher_experience.json | schoolorganizationid | 0 | 4498 | 0 | 101569.0 | 106971.0 | str:4602 |
+| teacher_experience.json | teachercount | 0 | 4602 | 0 | 0.0 | 499.0 | str:4602 |
+| teacher_experience.json | teacherpercent | 0 | 4602 | 0 | 0.0 | 100.0 | str:4602 |
+| teacher_experience.json | teachertotalcount | 0 | 4602 | 0 | 1.0 | 1654.0 | str:4602 |
+| wakids.json | county | 0 | 0 | 0 | None | None | str:210202 |
+| wakids.json | districtorganizationid | 0 | 210202 | 0 | 100117.0 | 100117.0 | str:210202 |
+| wakids.json | esdorganizationid | 0 | 210202 | 0 | 100006.0 | 100006.0 | str:210202 |
+| wakids.json | organizationid | 0 | 210202 | 0 | 100117.0 | 106750.0 | str:210202 |
+| wakids.json | organizationlevel | 0 | 0 | 0 | None | None | str:210202 |
+| wakids.json | washingtonstatecode | 0 | 210202 | 0 | 103300.0 | 103300.0 | str:210202 |
+| wakids.json | measurevalue | 0 | 28732 | 0 | 0.0 | 6.0 | str:209108 |
+| wakids.json | schoolorganizationid | 0 | 198456 | 0 | 101571.0 | 106750.0 | str:198456 |
+| wakids.json | percent | 0 | 170144 | 0 | 0.00051 | 1.0 | str:170144 |
+| wakids.json | denominator | 0 | 142813 | 0 | 10.0 | 2022.0 | str:142813 |
+| wakids.json | numerator | 0 | 142813 | 0 | 1.0 | 1781.0 | str:142813 |
+| wakids.json | developmentlevel | 0 | 0 | 0 | None | None | str:116380 |
+
+## Provenance And Citation Recommendations
+
+- Preserve the raw source file name and SHA-256 checksum for every staged record.
+- Store dataset name, reporting year field/value, district and school identifiers, organization level, grade/subgroup/category dimensions, and a deterministic record hash.
+- Add a future manifest ID and ingestion run ID before any database write so citations can point to the exact corpus snapshot and transformation run.
+- Keep citations record-addressable: source file + checksum + dataset + natural key + record hash is the minimum useful citation bundle.
+
+## Ingestion Design Recommendations
+
+- Use a staging model that stores raw JSON records unchanged, plus extracted normalized columns for identity, time, entity, subgroup, metric, and value.
+- Build dataset-specific normalized tables or views only after raw staging proves stable; the shared base dimensions are district, school, organization level, school year, grade, student/subgroup category, and metric.
+- Generate a record hash from canonicalized raw JSON and store a schema version for each dataset profile.
+- Treat numeric strings, percentages, suppressed values, and blank strings as normalization gates, not silent casts.
+- Require pre-write validation gates: expected files, checksums, top-level array shape, record counts, required identity fields, year ranges, and suppression handling.
+- Design the query layer to return both normalized values and provenance metadata so answer citations can quote the exact dataset record.
+
+## Risks And Open Questions
+
+- Natural keys vary by dataset; several tables need dataset-specific category/metric fields beyond district, school, and year.
+- Suppression and masking conventions appear as strings and blanks; they need explicit semantic mapping before numeric analysis.
+- Year fields appear stable as `schoolyear`, but downstream design should not assume every future OSPI export keeps the same name.
+- Some numeric values are string-encoded and may include percentages or non-numeric placeholders.
+- Metadata beyond filename/checksum is thin; future ingestion should attach a manifest ID, download/source URL metadata, and run ID.
+- This profile parsed the corpus locally and read-only; it does not prove production ingestion behavior.


### PR DESCRIPTION
## Summary

This is a docs-only PR that adds the reconciled OSPI authoritative data-layer roadmap and the companion read-only OSPI corpus profile report.

Included files:
- `docs/ai/architecture/ospi_authoritative_data_layer_roadmap_20260504.md`
- `docs/ai/ospi/ospi_corpus_profile_20260504T203334Z.md`

## Safety scope

- Docs-only.
- Includes the OSPI roadmap and read-only corpus profile.
- No ingestion.
- No database writes.
- No OSPI scripts or downloads.
- No `download_ospi.py` run.
- No OSPI corpus modifications.
- No indexing or embedding.
- No migrations.
- No production access.
- No Framework access.
- No deployment or promotion.

## Verification

- Confirmed `main` and `origin/main` were at `8f08baa900732da6cb7e10bc941a5c87c78629cd` before branching.
- Confirmed the staged set was exactly the two docs files above.
- Confirmed the commit contains only those two docs files.
- Pre-commit hooks passed for the docs-only commit, including private-key detection, large-file check, merge-conflict check, end-of-file fix, trailing-whitespace check, and hardcoded-secret detection.